### PR TITLE
Feat: 텍스트 다크 모드 대응 및 일기 내보내기 입력 날짜 유효성에 따른 색상 변화 로직 

### DIFF
--- a/app/src/main/java/com/egobook/app/ui/diary/view/DiaryExportDialogFragment.kt
+++ b/app/src/main/java/com/egobook/app/ui/diary/view/DiaryExportDialogFragment.kt
@@ -1,5 +1,6 @@
 package com.egobook.app.ui.diary.view
 
+import android.annotation.SuppressLint
 import android.content.DialogInterface
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
@@ -9,16 +10,26 @@ import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.EditText
 import android.widget.Toast
+import androidx.core.content.ContextCompat
 import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
+import com.egobook.app.R
 import com.egobook.app.databinding.FragmentDiaryExportDialogBinding
 import com.egobook.app.removeScreenBlur
+import com.egobook.app.ui.diary.viewmodel.DiariesViewModel
+import com.egobook.app.ui.diary.viewmodel.TermType
+import kotlinx.coroutines.launch
 
 class DiaryExportDialogFragment : DialogFragment() {
 
     private var _binding: FragmentDiaryExportDialogBinding? = null
     private val binding get() = _binding!!
+
+    private val viewmodel: DiariesViewModel by activityViewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -33,9 +44,94 @@ class DiaryExportDialogFragment : DialogFragment() {
         super.onViewCreated(view, savedInstanceState)
 
         setupDateInputWatchers()
+        setupObservers()
         setClickListener()
-        updateButtonState() // 초기 버튼 상태 설정
+        updateButtonState()
+    }
 
+    private fun setupObservers() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewmodel.isValidDate.collect { state ->
+                when (state) {
+                    TermType.StartFuture -> {
+                        binding.tvStartDate.setTextColor(ContextCompat.getColor(requireContext(), R.color.critical))
+                        binding.icStartDate.setColorFilter(
+                            ContextCompat.getColor(requireContext(), R.color.critical)
+                        )
+                        binding.tvLastDate.setTextColor(ContextCompat.getColor(requireContext(), R.color.neutral))
+                        binding.icEndDate.setColorFilter(
+                            ContextCompat.getColor(requireContext(), R.color.neutral)
+                        )
+                        binding.tvExportGuide.setText("미래 날짜는 내보낼 수 없어요")
+                        binding.tvExportGuide.setTextColor(ContextCompat.getColor(requireContext(), R.color.critical))
+                    }
+                    TermType.EndFuture -> {
+                        binding.tvStartDate.setTextColor(ContextCompat.getColor(requireContext(), R.color.neutral))
+                        binding.icStartDate.setColorFilter(
+                            ContextCompat.getColor(requireContext(), R.color.neutral)
+                        )
+                        binding.tvLastDate.setTextColor(ContextCompat.getColor(requireContext(), R.color.critical))
+                        binding.icEndDate.setColorFilter(
+                            ContextCompat.getColor(requireContext(), R.color.critical)
+                        )
+                        binding.tvExportGuide.setText("미래 날짜는 내보낼 수 없어요")
+                        binding.tvExportGuide.setTextColor(ContextCompat.getColor(requireContext(), R.color.critical))
+                    }
+                    TermType.Reverse -> {
+                        // 시작 날짜가 종료 날짜보다 늦을 경우 빨간색으로 표시
+                        binding.tvStartDate.setTextColor(ContextCompat.getColor(requireContext(), R.color.critical))
+                        binding.icStartDate.setColorFilter(
+                            ContextCompat.getColor(requireContext(), R.color.critical)
+                        )
+                        binding.btnPdf.isEnabled = false
+                        binding.btnText.isEnabled = false
+                        binding.tvExportGuide.setText("시작 날짜가 끝 날짜보다 이전이거나\n" +
+                                "같아야 해요")
+                        binding.tvExportGuide.setTextColor(ContextCompat.getColor(requireContext(), R.color.critical))
+                    }
+                    TermType.MoreThanOneYear -> {
+                        binding.tvStartDate.setTextColor(ContextCompat.getColor(requireContext(), R.color.critical))
+                        binding.icStartDate.setColorFilter(
+                            ContextCompat.getColor(requireContext(), R.color.critical)
+                        )
+                        binding.tvLastDate.setTextColor(ContextCompat.getColor(requireContext(), R.color.critical))
+                        binding.icEndDate.setColorFilter(
+                            ContextCompat.getColor(requireContext(), R.color.critical)
+                        )
+                        binding.tvExportGuide.setText("최대 1년 단위로 끊어서 내보낼 수 있어요")
+                        binding.tvExportGuide.setTextColor(ContextCompat.getColor(requireContext(), R.color.critical))
+                    }
+                    TermType.Valid -> {
+                        binding.tvStartDate.setTextColor(ContextCompat.getColor(requireContext(), R.color.neutral))
+                        binding.icStartDate.setColorFilter(
+                            ContextCompat.getColor(requireContext(), R.color.neutral)
+                        )
+                        binding.tvLastDate.setTextColor(ContextCompat.getColor(requireContext(), R.color.neutral))
+                        binding.icEndDate.setColorFilter(
+                            ContextCompat.getColor(requireContext(), R.color.neutral)
+                        )
+                        binding.btnPdf.isEnabled = true
+                        binding.btnText.isEnabled = true
+                        binding.tvExportGuide.setText("최대 1년 단위로 내보낼 수 있어요")
+                        binding.tvExportGuide.setTextColor(ContextCompat.getColor(requireContext(), R.color.neutral))
+                    }
+                    TermType.None -> {
+                        binding.tvStartDate.setTextColor(ContextCompat.getColor(requireContext(), R.color.neutral))
+                        binding.icStartDate.setColorFilter(
+                            ContextCompat.getColor(requireContext(), R.color.neutral)
+                        )
+                        binding.tvLastDate.setTextColor(ContextCompat.getColor(requireContext(), R.color.neutral))
+                        binding.icEndDate.setColorFilter(
+                            ContextCompat.getColor(requireContext(), R.color.neutral)
+                        )
+                        binding.btnPdf.isEnabled = false
+                        binding.btnText.isEnabled = false
+                        binding.tvExportGuide.setText("최대 1년 단위로 내보낼 수 있어요")
+                        binding.tvExportGuide.setTextColor(ContextCompat.getColor(requireContext(), R.color.neutral))
+                    }
+                }
+            }
+        }
     }
 
     private fun setClickListener() {
@@ -48,68 +144,73 @@ class DiaryExportDialogFragment : DialogFragment() {
     }
 
     private fun setupDateInputWatchers() {
-        // 년/월/일 입력 시 자동으로 "."을 추가해주는 TextWatcher
-        val dateWatcher = object : TextWatcher {
-            private var isFormatting = false // 무한 루프 방지 플래그
-            private var beforeTextLength = 0
 
-            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
-                beforeTextLength = s?.length ?: 0
-            }
+        fun createDateWatcher(editText: EditText): TextWatcher {
+            return object : TextWatcher {
+                private var isFormatting = false
 
-            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+                override fun afterTextChanged(s: Editable?) {
+                    if (isFormatting || s == null) return
 
-            override fun afterTextChanged(s: Editable?) {
-                if (isFormatting) return
+                    isFormatting = true
 
-                val currentLength = s?.length ?: 0
-                // 사용자가 글자를 추가했을 때만 동작
-                if (currentLength > beforeTextLength) {
-                    if (currentLength == 4 || currentLength == 7) {
-                        isFormatting = true
-                        s?.append('.')
-                        isFormatting = false
+                    val original = s.toString()
+                    val cursorPosition = editText.selectionStart
+
+                    val digits = original.replace(".", "").take(8)
+
+                    // 커서를 digit 기준으로 변환
+                    val digitsBeforeCursor = original
+                        .substring(0, cursorPosition)
+                        .count { it.isDigit() }
+
+                    val formatted = StringBuilder()
+                    var newCursor = 0
+
+                    for (i in digits.indices) {
+                        if (i == 4 || i == 6) {
+                            formatted.append('.')
+                        }
+                        formatted.append(digits[i])
+
+                        // cursor 위치 계산 (정확한 방식)
+                        if (i < digitsBeforeCursor) {
+                            newCursor = formatted.length
+                        }
                     }
+
+                    s.replace(0, s.length, formatted.toString())
+
+                    try {
+                        editText.setSelection(newCursor)
+                    } catch (e: Exception) {
+                        editText.setSelection(formatted.length)
+                    }
+
+                    isFormatting = false
                 }
+
+                override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+                override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
             }
         }
 
-        // 각 EditText에 TextWatcher를 적용.
-        binding.tvStartDate.addTextChangedListener(dateWatcher)
-        binding.tvLastDate.addTextChangedListener(dateWatcher)
+        // watcher 각각 따로 붙이기
+        binding.tvStartDate.addTextChangedListener(createDateWatcher(binding.tvStartDate))
+        binding.tvLastDate.addTextChangedListener(createDateWatcher(binding.tvLastDate))
 
-        // 날짜 유효성 검사를 위한 TextWatcher
+        // validation
         binding.tvStartDate.doAfterTextChanged { updateButtonState() }
         binding.tvLastDate.doAfterTextChanged { updateButtonState() }
     }
 
-    /**
-     * 날짜 입력 유효성 검사 후 버튼 상태 업데이트
-     * YYYY.MM.DD 형식(10자리)이 모두 입력되었을 때만 버튼 활성화
-     */
     private fun updateButtonState() {
         val startDate = binding.tvStartDate.text.toString()
         val lastDate = binding.tvLastDate.text.toString()
-
-        // YYYY.MM.DD 형식 확인 (10자리)
-        val isStartDateValid = startDate.length == 10 && isValidDateFormat(startDate)
-        val isLastDateValid = lastDate.length == 10 && isValidDateFormat(lastDate)
-
-        val isBothDatesValid = isStartDateValid && isLastDateValid
-
-        binding.btnPdf.isEnabled = isBothDatesValid
-        binding.btnText.isEnabled = isBothDatesValid
+        
+        // 뷰모델에서 날짜 선후 관계 및 형식 검사 수행
+        viewmodel.validateDates(startDate, lastDate)
     }
-
-    /**
-     * 날짜 형식 유효성 검사 (YYYY.MM.DD)
-     */
-    private fun isValidDateFormat(date: String): Boolean {
-        // 정규식: YYYY.MM.DD 형식
-        val datePattern = Regex("""\d{4}\.\d{2}\.\d{2}""")
-        return datePattern.matches(date)
-    }
-
 
     override fun onCancel(dialog: DialogInterface) {
         super.onCancel(dialog)

--- a/app/src/main/java/com/egobook/app/ui/diary/viewmodel/DiariesViewModel.kt
+++ b/app/src/main/java/com/egobook/app/ui/diary/viewmodel/DiariesViewModel.kt
@@ -12,10 +12,14 @@ import com.egobook.app.ui.diary.mapper.DiaryEntityMapper
 import com.egobook.app.util.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.emptyFlow
+import timber.log.Timber
 import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
 @HiltViewModel
@@ -24,6 +28,9 @@ class DiariesViewModel @Inject constructor(
 ) : ViewModel() {
     private val _state = MutableStateFlow(DiariesState())  // 뷰모델 내부 갱신용
     val state = _state.asStateFlow()    // 외부(ui) 읽기 전용
+
+    private val _isValidDate = MutableStateFlow<TermType>(TermType.None)
+    val isValidDate = _isValidDate.asStateFlow()
 
     init {
         loadDiaries(LocalDate.now(), null)
@@ -75,6 +82,66 @@ class DiariesViewModel @Inject constructor(
         //loadDailyCount(selectedDate)
     }
 
+    private fun onExport(event: ExportEvent) {
+        when(event) {
+            is ExportEvent.PDFExport -> {
+                // PDF 내보내기
+            }
+            is ExportEvent.TextExport -> {
+                // Text 내보내기
+            }
+        }
+    }
+
+    /**
+     * 날짜 유효성 검사 (시작 날짜가 종료 날짜보다 늦은지 확인)
+     */
+    fun validateDates(startDateStr: String, endDateStr: String) {
+        val datePattern = Regex("""\d{4}\.\d{2}\.\d{2}""")
+        if (!datePattern.matches(startDateStr) || !datePattern.matches(endDateStr)) {
+            _isValidDate.value = TermType.None
+            return
+        }
+
+        try {
+            val formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd")
+            val start = LocalDate.parse(startDateStr, formatter)
+            val end = LocalDate.parse(endDateStr, formatter)
+            val today = LocalDate.now()
+
+            // 미래 날짜 체크
+            if (start.isAfter(today)) {
+                _isValidDate.value = TermType.StartFuture
+                Timber.d("StartFuture")
+                return
+            }
+            if (end.isAfter(today)) {
+                _isValidDate.value = TermType.EndFuture
+                Timber.d("EndFuture")
+                return
+            }
+
+            // 시작 > 종료
+            if (start.isAfter(end)) {
+                _isValidDate.value = TermType.Reverse
+                Timber.d("Reverse")
+                return
+            }
+
+            // 1년 초과 체크
+            if (start.plusYears(1).isBefore(end)) {
+                _isValidDate.value = TermType.MoreThanOneYear
+                Timber.d("MoreThanOneYear")
+                return
+            }
+
+            _isValidDate.value = TermType.Valid
+
+        } catch (e: Exception) {
+            _isValidDate.value = TermType.None
+        }
+    }
+
     /**
      * 캐시 기반 dailyCount 조회 (캐시 없으면 API 호출)
      * btnAdd 클릭 시 48 체크용으로 사용
@@ -115,3 +182,18 @@ data class DiariesState(
     val monthText: String = selectedDate.monthValue.toString(),
     val dayText: String = selectedDate.dayOfMonth.toString()
 )
+
+sealed class TermType {
+    object None : TermType()
+    object StartFuture : TermType()
+    object EndFuture : TermType()
+    object Reverse : TermType()
+
+    object MoreThanOneYear: TermType()
+    object Valid: TermType()
+}
+
+sealed class ExportEvent {
+    data object PDFExport : ExportEvent()
+    data object TextExport : ExportEvent()
+}

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -139,6 +139,7 @@
                     android:gravity="center"
                     android:text="시작 시 이용약관 및\n개인정보 수집 및 이용에 동의하게 됩니다"
                     android:textSize="12sp"
+                    android:textColor="@color/neutral"
                     android:fontFamily="@font/arita_medium"
                     android:lineHeight="18sp"/>
 

--- a/app/src/main/res/layout/fragment_account.xml
+++ b/app/src/main/res/layout/fragment_account.xml
@@ -65,6 +65,7 @@
                 android:layout_weight="1"
                 android:text="계정"
                 android:textSize="20sp"
+                android:textColor="@color/neutral"
                 android:fontFamily="@font/arita_semibold"
                 android:gravity="center_vertical"/>
 

--- a/app/src/main/res/layout/fragment_calender.xml
+++ b/app/src/main/res/layout/fragment_calender.xml
@@ -90,6 +90,7 @@
                 android:text=""
                 tools:text="12월"
                 android:textSize="24sp"
+                android:textColor="@color/neutral"
                 android:layout_marginHorizontal="24dp"
                 android:fontFamily="@font/arita_semibold" />
 

--- a/app/src/main/res/layout/fragment_diary.xml
+++ b/app/src/main/res/layout/fragment_diary.xml
@@ -37,6 +37,7 @@
                 android:layout_height="21dp"
                 android:text="2025"
                 android:textSize="14sp"
+                android:textColor="@color/neutral"
                 android:fontFamily="@font/arita_semibold"
                 android:gravity="center"/>
 
@@ -50,6 +51,7 @@
                 android:layout_height="21dp"
                 android:text="12월"
                 android:textSize="14sp"
+                android:textColor="@color/neutral"
                 android:fontFamily="@font/arita_semibold"
                 android:gravity="center"/>
         </LinearLayout>
@@ -86,6 +88,7 @@
                 android:gravity="center"
                 android:text="10"
                 android:textSize="24sp"
+                android:textColor="@color/neutral"
                 android:fontFamily="@font/arita_semibold"/>
 
             <Space

--- a/app/src/main/res/layout/fragment_diary_export_dialog.xml
+++ b/app/src/main/res/layout/fragment_diary_export_dialog.xml
@@ -39,6 +39,7 @@
             android:paddingVertical="8dp">
 
             <ImageView
+                android:id="@+id/icStartDate"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:src="@drawable/ic_calendar" />
@@ -77,6 +78,7 @@
             android:paddingVertical="8dp">
 
             <ImageView
+                android:id="@+id/icEndDate"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:src="@drawable/ic_calendar" />
@@ -103,7 +105,8 @@
             android:fontFamily="@font/arita_medium"
             android:text="최대 1년 단위로 내보낼 수 있어요"
             android:textColor="@color/neutral_subtle"
-            android:textSize="12sp" />
+            android:textSize="12sp"
+            android:gravity="center"/>
 
         <!-- 하단 버튼 그룹 -->
         <LinearLayout


### PR DESCRIPTION
## 📝 작업 내용
- 텍스트 다크 모드 대응
- 일기 내보내기 입력 날짜 유효성에 따른 색상 변화 로직 

## 🔗 관련 이슈(선택)
- #이슈번호 → PR이 머지되도 이슈는 닫히지 않음
- Close #이슈번호 (일반적인 기능 구현) → PR이 머지되면 이슈도 같이 닫힘
- Fix #이슈번호 (버그 수정) → PR이 머지되면 이슈도 같이 닫힘
- 예시: Fix #25 (버튼 연타로 빠르게 클릭 시 앱 종료 버그)

## 📸 스크린샷
- 시각화 가능한 기능 구현 부분이 있으면 스크린샷을 같이 첨부해주세요.

## 💬 요구사항(선택)
- 팀원 분들이 리뷰 해주길 바라는 특정 부분이 있으면 작성해주세요.
- 팀원 분들이 확인 해주길 바라는 특정 부분이 있으면 작성해주세요.

## ✅ 체크리스트
- [ ] 관련 없는 변경사항 삭제 했는가? (불필요한 주석, 로그 등)
- [ ] 테스트 여부 (Unit Test 등)
- [ ] 커밋 목적에 맞게 유동적으로 추가하기...
