### PR TITLE
fix: MobileAds 초기화 완료 후 광고 로드하도록 수정

### DIFF
--- a/app/src/main/java/com/egobook/app/MainActivity.kt
+++ b/app/src/main/java/com/egobook/app/MainActivity.kt
@@ -36,9 +36,9 @@ class MainActivity : AppCompatActivity(), BlurController, NotificationController
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 
-        MobileAds.initialize(this)
-
-        loadAd()
+        MobileAds.initialize(this) {
+            loadAd()
+        }
         lifecycleScope.launch {
             try {
                 // 서버 확인용 (가벼운 API)


### PR DESCRIPTION
## 개요
MobileAds SDK 초기화 완료 콜백 안에서 `loadAd()`를 호출하도록 수정합니다.

## 변경 사항
- `MobileAds.initialize(this)` 직후 호출하던 `loadAd()`를 초기화 완료 콜백 내부로 이동

## 관련 이슈
Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 광고 초기화가 완료된 후 광고가 로드되도록 처리 순서를 개선했습니다.
  * 광고 표시의 안정성과 초기 로딩 동작이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->