### PR TITLE
fix: 점검 알람이 06:00 이후에도 노출되던 문제 수정

### DIFF
--- a/app/src/main/java/com/egobook/app/ui/login/view/IntroActivity.kt
+++ b/app/src/main/java/com/egobook/app/ui/login/view/IntroActivity.kt
@@ -62,7 +62,7 @@ class IntroActivity : ComponentActivity() {
         // IntroActivity UI를 보여주는 시간
         delay(1400)
 
-        // 점검 시간 체크 (03:00 ~ 09:00)
+        // 점검 시간 체크 (03:00 ~ 06:00)
         if (isMaintenanceTime()) {
             showMaintenanceDialog()
             return
@@ -86,7 +86,7 @@ class IntroActivity : ComponentActivity() {
     private fun isMaintenanceTime(): Boolean {
         val calendar = java.util.Calendar.getInstance()
         val hour = calendar.get(java.util.Calendar.HOUR_OF_DAY)
-        return hour in 3..6
+        return hour in 3..5
 //        return true
     }
 


### PR DESCRIPTION
## 개요
서버 점검 알람이 06:00까지만 떠야 하는데 06:59까지 노출되던 문제를 수정합니다. (06:40~50에도 알람이 뜨던 현상)

## 원인
`IntroActivity.isMaintenanceTime()`에서 `hour in 3..6`으로 체크하여 6시대(06:00~06:59) 전체가 점검 시간에 포함되어 있었습니다.

## 변경 사항
- `hour in 3..6` → `hour in 3..5`로 변경하여 점검 시간을 03:00~05:59로 수정 (06:00부터 정상 진입)
- 주석의 잘못된 시간 표기(03:00 ~ 09:00)를 실제 안내 문구와 동일한 03:00 ~ 06:00으로 정리

Fixes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 앱 점검 시간이 오전 3시~6시에서 오전 3시~5시로 조정되었습니다.
  * 점검 종료 후 앱을 더 일찍 이용할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->