### PR TITLE
fix: 03~06시 점검 취소로 점검 다이얼로그 주석 처리

### DIFF
--- a/app/src/main/java/com/egobook/app/MainActivity.kt
+++ b/app/src/main/java/com/egobook/app/MainActivity.kt
@@ -39,24 +39,25 @@ class MainActivity : AppCompatActivity(), BlurController, NotificationController
         MobileAds.initialize(this) {
             loadAd()
         }
-        lifecycleScope.launch {
-            try {
-                // 서버 확인용 (가벼운 API)
-                // TODO: 나중에 ping API 생기면 교체
-                // 임시로 아무 API 하나 호출하는 구조 필요
-
-            } catch (e: Exception) {
-                val message = e.message ?: ""
-
-                if (
-                    message.contains("timeout", true) ||
-                    message.contains("Unable to resolve host", true) ||
-                    message.contains("Failed to connect", true)
-                ) {
-                    showMaintenanceDialog()
-                }
-            }
-        }
+        // 점검 취소로 인한 주석 처리 (서버 점검 다이얼로그)
+//        lifecycleScope.launch {
+//            try {
+//                // 서버 확인용 (가벼운 API)
+//                // TODO: 나중에 ping API 생기면 교체
+//                // 임시로 아무 API 하나 호출하는 구조 필요
+//
+//            } catch (e: Exception) {
+//                val message = e.message ?: ""
+//
+//                if (
+//                    message.contains("timeout", true) ||
+//                    message.contains("Unable to resolve host", true) ||
+//                    message.contains("Failed to connect", true)
+//                ) {
+//                    showMaintenanceDialog()
+//                }
+//            }
+//        }
 
         applyDefaultInsets(binding.main)
         applyDefaultInsets(binding.fcvNotificationDrawer)
@@ -186,15 +187,16 @@ class MainActivity : AppCompatActivity(), BlurController, NotificationController
         binding.root.closeDrawer(binding.fcvNotificationDrawer)
     }
 
-    private fun showMaintenanceDialog() {
-        android.app.AlertDialog.Builder(this)
-            .setTitle("점검 중")
-            .setMessage("서버 점검 중입니다.\n점검 시간: 03:00 ~ 06:00")
-            .setPositiveButton("확인") { _, _ ->
-                finishAffinity()
-            }
-            .setCancelable(false)
-            .show()
-    }
+    // 점검 취소로 인한 주석 처리
+//    private fun showMaintenanceDialog() {
+//        android.app.AlertDialog.Builder(this)
+//            .setTitle("점검 중")
+//            .setMessage("서버 점검 중입니다.\n점검 시간: 03:00 ~ 06:00")
+//            .setPositiveButton("확인") { _, _ ->
+//                finishAffinity()
+//            }
+//            .setCancelable(false)
+//            .show()
+//    }
 
 }

--- a/app/src/main/java/com/egobook/app/ui/login/view/IntroActivity.kt
+++ b/app/src/main/java/com/egobook/app/ui/login/view/IntroActivity.kt
@@ -62,11 +62,11 @@ class IntroActivity : ComponentActivity() {
         // IntroActivity UI를 보여주는 시간
         delay(1400)
 
-        // 점검 시간 체크 (03:00 ~ 06:00)
-        if (isMaintenanceTime()) {
-            showMaintenanceDialog()
-            return
-        }
+        // 점검 취소로 인한 주석 처리 (03:00 ~ 06:00 점검 다이얼로그)
+//        if (isMaintenanceTime()) {
+//            showMaintenanceDialog()
+//            return
+//        }
 
         //액세스 토큰 읽기
         val accessToken = userInfoStorage.getAccessToken().first()
@@ -83,21 +83,22 @@ class IntroActivity : ComponentActivity() {
             navigateToLogin()
         }
     }
-    private fun isMaintenanceTime(): Boolean {
-        val calendar = java.util.Calendar.getInstance()
-        val hour = calendar.get(java.util.Calendar.HOUR_OF_DAY)
-        return hour in 3..5
-//        return true
-    }
-
-    private fun showMaintenanceDialog() {
-        android.app.AlertDialog.Builder(this)
-            .setTitle("점검 중")
-            .setMessage("서버 점검 중입니다.\n점검 시간: 03:00 ~ 06:00")
-            .setPositiveButton("확인") { _, _ -> finishAffinity() }
-            .setCancelable(false)
-            .show()
-    }
+    // 점검 취소로 인한 주석 처리
+//    private fun isMaintenanceTime(): Boolean {
+//        val calendar = java.util.Calendar.getInstance()
+//        val hour = calendar.get(java.util.Calendar.HOUR_OF_DAY)
+//        return hour in 3..5
+////        return true
+//    }
+//
+//    private fun showMaintenanceDialog() {
+//        android.app.AlertDialog.Builder(this)
+//            .setTitle("점검 중")
+//            .setMessage("서버 점검 중입니다.\n점검 시간: 03:00 ~ 06:00")
+//            .setPositiveButton("확인") { _, _ -> finishAffinity() }
+//            .setCancelable(false)
+//            .show()
+//    }
 
     private fun navigateToMain() {
         val intent = Intent(this, MainActivity::class.java)

--- a/app/src/main/java/com/egobook/app/ui/login/view/LoginActivity.kt
+++ b/app/src/main/java/com/egobook/app/ui/login/view/LoginActivity.kt
@@ -224,22 +224,22 @@ import javax.inject.Inject
 
                         val message = state.error.message ?: ""
 
-                        //서버 꺼짐 / 네트워크 에러
-                        if (
-                            message.contains("timeout", true) ||
-                            message.contains("Unable to resolve host", true) ||
-                            message.contains("Failed to connect", true)
-                        ) {
-                            showMaintenanceDialog()
-                        }
-                        // 일반 에러
-                        else {
-                            Toast.makeText(
-                                this@LoginActivity,
-                                message.ifEmpty { "알 수 없는 오류가 발생했습니다" },
-                                Toast.LENGTH_SHORT
-                            ).show()
-                        }
+                        // 점검 취소로 인한 주석 처리 (서버 꺼짐 / 네트워크 에러 시 점검 다이얼로그)
+//                        if (
+//                            message.contains("timeout", true) ||
+//                            message.contains("Unable to resolve host", true) ||
+//                            message.contains("Failed to connect", true)
+//                        ) {
+//                            showMaintenanceDialog()
+//                        }
+//                        // 일반 에러
+//                        else {
+                        Toast.makeText(
+                            this@LoginActivity,
+                            message.ifEmpty { "알 수 없는 오류가 발생했습니다" },
+                            Toast.LENGTH_SHORT
+                        ).show()
+//                        }
                     }
                     else -> {
                         binding.progressBar.visibility = View.GONE
@@ -282,16 +282,17 @@ import javax.inject.Inject
             finish()
         }
 
-        private fun showMaintenanceDialog() {
-            android.app.AlertDialog.Builder(this)
-                .setTitle("점검 중")
-                .setMessage("서버 점검 중입니다.\n점검 시간: 03:00 ~ 06:00")
-                .setPositiveButton("확인") { _, _ ->
-                    finishAffinity() // 앱 종료
-                }
-                .setCancelable(false)
-                .show()
-        }
+        // 점검 취소로 인한 주석 처리
+//        private fun showMaintenanceDialog() {
+//            android.app.AlertDialog.Builder(this)
+//                .setTitle("점검 중")
+//                .setMessage("서버 점검 중입니다.\n점검 시간: 03:00 ~ 06:00")
+//                .setPositiveButton("확인") { _, _ ->
+//                    finishAffinity() // 앱 종료
+//                }
+//                .setCancelable(false)
+//                .show()
+//        }
 
 
 


### PR DESCRIPTION
## 📝 작업 내용
- 03:00 ~ 06:00 정기 점검이 취소되어 점검 안내 다이얼로그 관련 코드를 주석 처리했습니다. (추후 점검 재개 시 복구 가능하도록 삭제하지 않고 주석 유지)
- `IntroActivity`: 앱 실행 시 점검 시간(03~06시) 체크 및 다이얼로그 노출 로직 주석 처리
- `LoginActivity`: 네트워크 에러 시 점검 다이얼로그 대신 일반 에러 토스트가 노출되도록 변경 (다이얼로그 로직 주석 처리)
- `MainActivity`: 서버 연결 실패 시 점검 다이얼로그 노출 로직 주석 처리

## 🔗 관련 이슈(선택)
- Fix #100 (03~06시 점검 취소에 따른 점검 다이얼로그 주석 처리)

## 📸 스크린샷
- UI 변경 없음 (다이얼로그 미노출)

## 💬 요구사항(선택)
- 점검 재개 시 주석 해제만으로 복구 가능한 구조인지 확인 부탁드립니다.
- LoginActivity에서 네트워크 에러 시 이제 토스트로 안내되는 점 확인 부탁드립니다.

## ✅ 체크리스트
- [x] 관련 없는 변경사항 삭제 했는가? (불필요한 주석, 로그 등)
- [x] 테스트 여부 (compileDebugKotlin 통과 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 앱 시작 시 서버 점검 상태에 따른 유지보수 안내 대화상자가 표시되지 않습니다.
  * 정해진 점검 시간에도 점검 안내 없이 로그인 상태에 따라 메인 또는 로그인 화면으로 이동합니다.
  * 로그인 중 네트워크 및 시간 초과 오류는 유지보수 안내 대신 기존과 같이 토스트 메시지로 표시됩니다.
  * 점검 관련 조건으로 인해 앱 이용이 중단되는 흐름이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->