### PR TITLE
fix: 마이페이지 하단 텍스트 색상을 디자인에 맞게 회색으로 변경 (#104)

### DIFF
--- a/app/src/main/res/layout/fragment_account.xml
+++ b/app/src/main/res/layout/fragment_account.xml
@@ -557,7 +557,7 @@
                 android:gravity="center"
                 android:text="회원 탈퇴"
                 android:textSize="14sp"
-                android:textColor="@color/neutral"
+                android:textColor="@color/neutral_subtle"
                 android:fontFamily="@font/arita_semibold"/>
 
             <TextView
@@ -568,7 +568,7 @@
                 android:gravity="center"
                 android:text="이용약관 및 개인정보처리"
                 android:textSize="14sp"
-                android:textColor="@color/neutral"
+                android:textColor="@color/neutral_subtle"
                 android:fontFamily="@font/arita_semibold"/>
             
             <Space


### PR DESCRIPTION
## 개요
마이페이지 하단의 "회원 탈퇴", "이용약관 및 개인정보처리" 텍스트가 검은색으로 표시되던 문제를 수정합니다.

Closes #104

## 변경 사항
- `fragment_account.xml`의 `tv_delete_account`, `tv_promise` 텍스트 색상을 `@color/neutral`(#191818) → `@color/neutral_subtle`(#969696)로 변경
- "고객지원"(`tv_support`) 타이틀은 기존 검은색 유지

<img width="286" height="153" alt="image" src="https://github.com/user-attachments/assets/ad7ec6ab-66fe-480d-a58d-8b2f7dd1ee21" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 계정 화면 하단의 회원 탈퇴 및 이용약관·개인정보처리 안내 문구 색상을 더 은은한 색상으로 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->