### PR TITLE
[✨Feat] 통계 탭 진입 시 전면 광고 표시

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -50,6 +50,9 @@ android {
         val admobRewardedAdUnitId =
             localProperties.getProperty("ADMOB_REWARDED_AD_INK_UNIT_ID") ?: "ca-app-pub-3940256099942544/5224354917"
         buildConfigField("String", "ADMOB_REWARDED_AD_INK_UNIT_ID", "\"$admobRewardedAdUnitId\"")
+        val admobInterstitialStatisticsUnitId =
+            localProperties.getProperty("ADMOB_INTERSTITIAL_STATISTICS_UNIT_ID") ?: "ca-app-pub-3940256099942544/1033173712"
+        buildConfigField("String", "ADMOB_INTERSTITIAL_STATISTICS_UNIT_ID", "\"$admobInterstitialStatisticsUnitId\"")
 
         println("ADMOB_APP_ID = ${localProperties.getProperty("ADMOB_APP_ID")}")
 

--- a/app/src/main/java/com/egobook/app/ui/counseling/view/EgoRoomStatisticsFragment.kt
+++ b/app/src/main/java/com/egobook/app/ui/counseling/view/EgoRoomStatisticsFragment.kt
@@ -5,6 +5,7 @@ import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import android.text.Spannable
+import android.util.Log
 import android.text.SpannableStringBuilder
 import android.text.style.StyleSpan
 import android.view.View
@@ -20,6 +21,7 @@ import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import com.egobook.app.BuildConfig
 import com.egobook.app.R
 import com.egobook.app.databinding.FragmentEgoRoomStatisticsBinding
 import com.egobook.app.domain.model.MonthlyAverage
@@ -36,6 +38,12 @@ import com.github.mikephil.charting.data.Entry
 import com.github.mikephil.charting.data.LineData
 import com.github.mikephil.charting.data.LineDataSet
 import com.github.mikephil.charting.formatter.IndexAxisValueFormatter
+import com.google.android.gms.ads.AdError
+import com.google.android.gms.ads.AdRequest
+import com.google.android.gms.ads.FullScreenContentCallback
+import com.google.android.gms.ads.LoadAdError
+import com.google.android.gms.ads.interstitial.InterstitialAd
+import com.google.android.gms.ads.interstitial.InterstitialAdLoadCallback
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import kotlin.math.abs
@@ -45,13 +53,54 @@ class EgoRoomStatisticsFragment : Fragment(R.layout.fragment_ego_room_statistics
     private lateinit var binding: FragmentEgoRoomStatisticsBinding
     private val viewModel: StatisticsViewModel by activityViewModels()
     private var tooltipPopup: PopupWindow? = null
+    private var interstitialAd: InterstitialAd? = null
+    private var hasShownInterstitialAd = false
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding = FragmentEgoRoomStatisticsBinding.bind(view)
+        loadInterstitialAd()
         initViews()
         initObservers()
         fetchData()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        showInterstitialAdIfReady()
+    }
+
+    private fun loadInterstitialAd() {
+        InterstitialAd.load(
+            requireContext(),
+            BuildConfig.ADMOB_INTERSTITIAL_STATISTICS_UNIT_ID,
+            AdRequest.Builder().build(),
+            object : InterstitialAdLoadCallback() {
+                override fun onAdLoaded(ad: InterstitialAd) {
+                    interstitialAd = ad
+                    Log.d("AdMob", "통계 전면 광고 로드 성공")
+                    if (isResumed) showInterstitialAdIfReady()
+                }
+
+                override fun onAdFailedToLoad(adError: LoadAdError) {
+                    interstitialAd = null
+                    Log.d("AdMob", "통계 전면 광고 로드 실패, $adError")
+                }
+            }
+        )
+    }
+
+    private fun showInterstitialAdIfReady() {
+        if (hasShownInterstitialAd) return
+        val ad = interstitialAd ?: return
+        hasShownInterstitialAd = true
+        interstitialAd = null
+        ad.fullScreenContentCallback = object : FullScreenContentCallback() {
+            override fun onAdFailedToShowFullScreenContent(adError: AdError) {
+                Log.d("AdMob", "통계 전면 광고 표시 실패, $adError")
+            }
+        }
+        ad.show(requireActivity())
     }
 
     private fun initViews() {


### PR DESCRIPTION
## 📝 작업 내용
- 통계 탭(EgoRoomStatisticsFragment) 진입 시 전면 광고(Interstitial Ad)를 표시합니다.
- 광고 단위 ID는 `local.properties`의 `ADMOB_INTERSTITIAL_STATISTICS_UNIT_ID`에서 읽어 BuildConfig로 주입하며, 미설정 시 AdMob 테스트 전면 광고 단위로 fallback합니다. (현재는 테스트 광고로 진행)
- 화면 생성 시 광고를 미리 로드하고, 통계 탭이 실제로 보이는 시점(onResume)에 노출합니다.
- `hasShownInterstitialAd` 플래그로 에고룸 방문당 1회만 노출하여 탭 전환/광고 닫기 시 재노출(무한 루프)을 방지합니다.
- 광고 로드·표시 실패 시 로그만 남기고 통계 화면은 정상 동작합니다.

## 🔗 관련 이슈
- Close #106

 📸 스크린샷

https://github.com/user-attachments/assets/118e2be8-35ac-48ee-bc5c-3bbb05707da3


## 💬 요구사항(선택)
- `local.properties`에 아래 값을 추가해야 합니다 (미설정 시 테스트 광고로 동작):
  ```
  ADMOB_INTERSTITIAL_STATISTICS_UNIT_ID=ca-app-pub-3940256099942544/1033173712
  ```
- 광고 노출 정책(방문당 1회)이 기획 의도와 맞는지 확인 부탁드립니다.

## ✅ 체크리스트
- [x] 관련 없는 변경사항 삭제 했는가? (불필요한 주석, 로그 등)
- [x] :app:compileDebugKotlin 빌드 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)