### PR TITLE
🐛Fix - 비정상 종료 및 주간 리포트 버그

### DIFF
--- a/app/src/main/java/com/egobook/app/data/api/CounselingApiService.kt
+++ b/app/src/main/java/com/egobook/app/data/api/CounselingApiService.kt
@@ -65,7 +65,7 @@ interface CounselingApiService {
     suspend fun unlockWeeklyReport(
         @Path("startDate") startDate: String,
         @Query("unlockType") unlockType: WeeklyReportUnlockType
-    ): ApiResponse<Unit>
+    ): ApiResponse<String?>
 
 
     @GET("/ego-room/counseling-tone")

--- a/app/src/main/java/com/egobook/app/store/ui/StoreViewModel.kt
+++ b/app/src/main/java/com/egobook/app/store/ui/StoreViewModel.kt
@@ -104,6 +104,9 @@ class StoreViewModel @Inject constructor(
             val permanent = shopRepository.loadEquippedItems()
             _permanentItems.value = permanent
             _equippedItems.value = permanent
+        } catch (e: Exception) {
+            Log.e("StoreViewModel", "Store initialize failed", e)
+            _toastEvent.emit("상점 정보를 불러오지 못했습니다.")
         } finally {
             hideLoading()
         }

--- a/app/src/main/java/com/egobook/app/ui/counseling/view/EgoRoomWeeklyReportFragment.kt
+++ b/app/src/main/java/com/egobook/app/ui/counseling/view/EgoRoomWeeklyReportFragment.kt
@@ -6,7 +6,7 @@ import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
+import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -28,7 +28,7 @@ import kotlinx.coroutines.launch
 @AndroidEntryPoint
 class EgoRoomWeeklyReportFragment : Fragment(R.layout.fragment_ego_room_weekly_report) {
     private lateinit var binding: FragmentEgoRoomWeeklyReportBinding
-    private val viewModel: WeeklyReportViewModel by viewModels()
+    private val viewModel: WeeklyReportViewModel by activityViewModels()
     private val counselingWeeklyReportAdapter = CounselingWeeklyReportAdapter { item ->
         if(item.isLocked) {
             val dialog = WeeklyReportUnlockDialog(startDate = item.startDate)
@@ -85,6 +85,13 @@ class EgoRoomWeeklyReportFragment : Fragment(R.layout.fragment_ego_room_weekly_r
                 launch {
                     viewModel.weeklyReportList.collectLatest { pagingData ->
                         counselingWeeklyReportAdapter.submitData(lifecycle, pagingData)
+                    }
+                }
+                launch {
+                    viewModel.unlockWeeklyReportResult.collect { state ->
+                        if (state is UiState.Success<Unit>) {
+                            counselingWeeklyReportAdapter.refresh()
+                        }
                     }
                 }
                 launch {

--- a/app/src/main/java/com/egobook/app/ui/counseling/view/WeeklyReportUnlockDialog.kt
+++ b/app/src/main/java/com/egobook/app/ui/counseling/view/WeeklyReportUnlockDialog.kt
@@ -35,6 +35,7 @@ class WeeklyReportUnlockDialog(private val startDate: String): DialogFragment(R.
     private val viewModel: WeeklyReportViewModel by activityViewModels()
     private var rewardedAd: RewardedAd? = null
     private var isLoadingRewardedAd = false
+    private var isUnlockRequestInFlight = false
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         return Dialog(requireContext()).apply {
@@ -76,6 +77,8 @@ class WeeklyReportUnlockDialog(private val startDate: String): DialogFragment(R.
 
     private fun initListeners() = with(binding) {
         btnWeeklyReportUnlockUseInk.setOnClickListener {
+            if (isUnlockRequestInFlight) return@setOnClickListener
+            isUnlockRequestInFlight = true
             viewModel.getUserInfo()
         }
         btnWeeklyReportUnlockWatchAdd.setOnClickListener {
@@ -121,6 +124,7 @@ class WeeklyReportUnlockDialog(private val startDate: String): DialogFragment(R.
 
             override fun onAdFailedToShowFullScreenContent(adError: AdError) {
                 rewardedAd = null
+                loadRewardedAd()
                 showCustomToast("광고를 표시하지 못했어요. 잠시 후 다시 시도해주세요.")
             }
         }
@@ -135,7 +139,9 @@ class WeeklyReportUnlockDialog(private val startDate: String): DialogFragment(R.
                 launch {
                     viewModel.userInfo.collect { state ->
                         when(state) {
-                            is UiState.Failure -> {}
+                            is UiState.Failure -> {
+                                isUnlockRequestInFlight = false
+                            }
                             UiState.Idle -> {}
                             UiState.Loading -> {}
                             is UiState.Success<User> -> {
@@ -144,6 +150,7 @@ class WeeklyReportUnlockDialog(private val startDate: String): DialogFragment(R.
                                 if (currentInk >= INK_PRICE) {
                                     viewModel.unlockWeeklyReport(startDate = startDate, unlockType = WeeklyReportUnlockType.INK)
                                 } else {
+                                    isUnlockRequestInFlight = false
                                     showCustomToast("현재 잉크가 부족합니다!")
                                 }
                             }
@@ -154,11 +161,13 @@ class WeeklyReportUnlockDialog(private val startDate: String): DialogFragment(R.
                     viewModel.unlockWeeklyReportResult.collect { state ->
                         when(state) {
                             is UiState.Failure -> {
+                                isUnlockRequestInFlight = false
                                 showCustomToast("잠금 해제에 실패했습니다. 잠시 후 다시 시도해주세요.")
                             }
                             UiState.Idle -> {}
                             UiState.Loading -> {}
                             is UiState.Success<Unit> -> {
+                                isUnlockRequestInFlight = false
                                 showCustomToast("주간 보고서 잠금이 해제 되었습니다!")
                                 val action = EgoRoomFragmentDirections.actionMenuEgoRoomToCounselingWeeklyReportDetailFragment(startDate = startDate)
                                 findNavController().navigate(action)

--- a/app/src/main/java/com/egobook/app/ui/counseling/view/WeeklyReportUnlockDialog.kt
+++ b/app/src/main/java/com/egobook/app/ui/counseling/view/WeeklyReportUnlockDialog.kt
@@ -3,8 +3,10 @@ package com.egobook.app.ui.counseling.view
 import android.app.Dialog
 import android.graphics.Color
 import android.os.Bundle
+import android.util.Log
 import android.view.View
-import android.widget.Toast
+import android.view.ViewGroup
+import android.widget.TextView
 import androidx.core.graphics.drawable.toDrawable
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.activityViewModels
@@ -12,16 +14,27 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
+import com.egobook.app.BuildConfig
 import com.egobook.app.R
 import com.egobook.app.databinding.DialogWeeklyReportUnlockBinding
+import com.egobook.app.domain.model.counseling.WeeklyReportUnlockType
 import com.egobook.app.ui.counseling.viewmodel.WeeklyReportViewModel
 import com.egobook.app.ui.home.user.User
 import com.egobook.app.util.UiState
+import com.google.android.gms.ads.AdError
+import com.google.android.gms.ads.AdRequest
+import com.google.android.gms.ads.FullScreenContentCallback
+import com.google.android.gms.ads.LoadAdError
+import com.google.android.gms.ads.rewarded.RewardedAd
+import com.google.android.gms.ads.rewarded.RewardedAdLoadCallback
+import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 
 class WeeklyReportUnlockDialog(private val startDate: String): DialogFragment(R.layout.dialog_weekly_report_unlock) {
     private lateinit var binding: DialogWeeklyReportUnlockBinding
     private val viewModel: WeeklyReportViewModel by activityViewModels()
+    private var rewardedAd: RewardedAd? = null
+    private var isLoadingRewardedAd = false
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         return Dialog(requireContext()).apply {
@@ -34,6 +47,31 @@ class WeeklyReportUnlockDialog(private val startDate: String): DialogFragment(R.
         binding = DialogWeeklyReportUnlockBinding.bind(view)
         initListeners()
         initObservers()
+        loadRewardedAd()
+    }
+
+    private fun showCustomToast(message: String) {
+        val rootView = requireActivity().findViewById<View>(android.R.id.content)
+        val snackBar = Snackbar.make(rootView, "", Snackbar.LENGTH_SHORT)
+
+        val customView = layoutInflater.inflate(R.layout.toast_message, null)
+        customView.findViewById<TextView>(R.id.tv_message).text = message
+
+        val layout = snackBar.view as ViewGroup
+        layout.setPadding(0, 0, 0, 0)
+        layout.setBackgroundColor(Color.TRANSPARENT)
+        layout.addView(customView, 0)
+
+        val bottomNav = requireActivity().findViewById<View>(R.id.bottom_navigation)
+        if (bottomNav != null) {
+            snackBar.anchorView = bottomNav
+            val extra = (9 * resources.displayMetrics.density).toInt()
+            val params = snackBar.view.layoutParams as ViewGroup.MarginLayoutParams
+            params.bottomMargin += extra
+            snackBar.view.layoutParams = params
+        }
+
+        snackBar.show()
     }
 
     private fun initListeners() = with(binding) {
@@ -41,7 +79,53 @@ class WeeklyReportUnlockDialog(private val startDate: String): DialogFragment(R.
             viewModel.getUserInfo()
         }
         btnWeeklyReportUnlockWatchAdd.setOnClickListener {
-            // TODO: 에드몹 연결 + 주간 리포트 열기
+            showRewardedAd()
+        }
+    }
+
+    private fun loadRewardedAd() {
+        if (isLoadingRewardedAd || rewardedAd != null) return
+        isLoadingRewardedAd = true
+        RewardedAd.load(
+            requireContext(),
+            BuildConfig.ADMOB_REWARDED_AD_INK_UNIT_ID,
+            AdRequest.Builder().build(),
+            object : RewardedAdLoadCallback() {
+                override fun onAdLoaded(ad: RewardedAd) {
+                    isLoadingRewardedAd = false
+                    rewardedAd = ad
+                    Log.d("AdMob", "주간 리포트 리워드 광고 로드 성공")
+                }
+
+                override fun onAdFailedToLoad(adError: LoadAdError) {
+                    isLoadingRewardedAd = false
+                    rewardedAd = null
+                    Log.d("AdMob", "주간 리포트 리워드 광고 로드 실패, $adError")
+                }
+            }
+        )
+    }
+
+    private fun showRewardedAd() {
+        val ad = rewardedAd
+        if (ad == null) {
+            showCustomToast("광고를 준비 중이에요. 잠시 후 다시 시도해주세요.")
+            loadRewardedAd()
+            return
+        }
+        ad.fullScreenContentCallback = object : FullScreenContentCallback() {
+            override fun onAdDismissedFullScreenContent() {
+                rewardedAd = null
+                loadRewardedAd()
+            }
+
+            override fun onAdFailedToShowFullScreenContent(adError: AdError) {
+                rewardedAd = null
+                showCustomToast("광고를 표시하지 못했어요. 잠시 후 다시 시도해주세요.")
+            }
+        }
+        ad.show(requireActivity()) {
+            viewModel.unlockWeeklyReport(startDate = startDate, unlockType = WeeklyReportUnlockType.AD)
         }
     }
 
@@ -58,13 +142,9 @@ class WeeklyReportUnlockDialog(private val startDate: String): DialogFragment(R.
                                 val userInfo = state.data
                                 val currentInk = userInfo.ink.value
                                 if (currentInk >= INK_PRICE) {
-//                                    viewModel.unlockWeeklyReport(startDate = startDate, unlockType = WeeklyReportUnlockType.INK)
-                                    Toast.makeText(context, "잠금을 해제하였습니다.", Toast.LENGTH_SHORT).show()
-                                    val action = EgoRoomFragmentDirections.actionMenuEgoRoomToCounselingWeeklyReportDetailFragment(startDate = startDate)
-                                    findNavController().navigate(action)
-                                    dismiss()
+                                    viewModel.unlockWeeklyReport(startDate = startDate, unlockType = WeeklyReportUnlockType.INK)
                                 } else {
-                                    Toast.makeText(context, "현재 잉크가 부족합니다!", Toast.LENGTH_SHORT).show()
+                                    showCustomToast("현재 잉크가 부족합니다!")
                                 }
                             }
                         }
@@ -73,13 +153,16 @@ class WeeklyReportUnlockDialog(private val startDate: String): DialogFragment(R.
                 launch {
                     viewModel.unlockWeeklyReportResult.collect { state ->
                         when(state) {
-                            is UiState.Failure -> {}
+                            is UiState.Failure -> {
+                                showCustomToast("잠금 해제에 실패했습니다. 잠시 후 다시 시도해주세요.")
+                            }
                             UiState.Idle -> {}
                             UiState.Loading -> {}
                             is UiState.Success<Unit> -> {
-                                Toast.makeText(context, "주간 보고서 잠금이 해제 되었습니다!", Toast.LENGTH_SHORT).show()
+                                showCustomToast("주간 보고서 잠금이 해제 되었습니다!")
                                 val action = EgoRoomFragmentDirections.actionMenuEgoRoomToCounselingWeeklyReportDetailFragment(startDate = startDate)
                                 findNavController().navigate(action)
+                                dismiss()
                             }
                         }
                     }

--- a/app/src/main/res/layout/toast_message.xml
+++ b/app/src/main/res/layout/toast_message.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/toast_message_container"
+    android:layout_width="match_parent"
+    android:layout_height="56dp"
+    android:layout_marginHorizontal="16dp"
+    android:background="@drawable/bg_custom_toast"
+    android:paddingHorizontal="24dp"
+    android:paddingVertical="16dp">
+
+    <TextView
+        android:id="@+id/tv_message"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="14sp"
+        android:textColor="@color/neutral"
+        android:fontFamily="@font/arita_semibold"
+        android:gravity="center"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        tools:text="주간 보고서 잠금이 해제 되었습니다!"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/toast_message.xml
+++ b/app/src/main/res/layout/toast_message.xml
@@ -4,7 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/toast_message_container"
     android:layout_width="match_parent"
-    android:layout_height="56dp"
+    android:layout_height="wrap_content"
+    android:minHeight="56dp"
     android:layout_marginHorizontal="16dp"
     android:background="@drawable/bg_custom_toast"
     android:paddingHorizontal="24dp"
@@ -12,7 +13,7 @@
 
     <TextView
         android:id="@+id/tv_message"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:textSize="14sp"
         android:textColor="@color/neutral"

--- a/app/src/test/java/com/egobook/app/store/ui/StoreViewModelTest.kt
+++ b/app/src/test/java/com/egobook/app/store/ui/StoreViewModelTest.kt
@@ -1,0 +1,88 @@
+package com.egobook.app.store.ui
+
+import android.util.Log
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.egobook.app.store.data.ShopRepository
+import com.egobook.app.ui.home.repository.UserRepository
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class StoreViewModelTest {
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    private lateinit var shopRepository: ShopRepository
+    private lateinit var userRepository: UserRepository
+    private lateinit var viewModel: StoreViewModel
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        mockkStatic(Log::class)
+        every { Log.e(any(), any(), any()) } returns 0
+        every { Log.d(any(), any()) } returns 0
+        shopRepository = mockk()
+        userRepository = mockk()
+        every { shopRepository.itemStream } returns flowOf(emptyList())
+        viewModel = StoreViewModel(shopRepository = shopRepository, userRepository = userRepository)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        unmockkStatic(Log::class)
+    }
+
+    @Test
+    fun `initialize 도중 예외가 발생해도 크래시 없이 토스트 이벤트를 방출한다`() = runTest {
+        // Given
+        coEvery { userRepository.load() } throws RuntimeException("network error")
+        coEvery { shopRepository.initialize() } throws RuntimeException("HTTP 401")
+
+        val toastEvents = mutableListOf<String>()
+        val job = launch { viewModel.toastEvent.toList(toastEvents) }
+        runCurrent()
+
+        // When
+        viewModel.initialize()
+
+        // Then
+        job.cancel()
+        assertEquals(listOf("상점 정보를 불러오지 못했습니다."), toastEvents)
+    }
+
+    @Test
+    fun `initialize 성공 시 장착 아이템 목록을 반영한다`() = runTest {
+        // Given
+        coEvery { userRepository.load() } throws RuntimeException("ink load skipped for this test")
+        coEvery { shopRepository.initialize() } returns Unit
+        coEvery { shopRepository.loadEquippedItems() } returns emptyList()
+
+        // When
+        viewModel.initialize()
+
+        // Then
+        assertEquals(emptyList<CustomItem>(), viewModel.equippedItems.value)
+    }
+}

--- a/app/src/test/java/com/egobook/app/store/ui/StoreViewModelTest.kt
+++ b/app/src/test/java/com/egobook/app/store/ui/StoreViewModelTest.kt
@@ -3,6 +3,9 @@ package com.egobook.app.store.ui
 import android.util.Log
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.egobook.app.store.data.ShopRepository
+import com.egobook.app.store.data.model.ItemStatus
+import com.egobook.app.store.data.model.ItemType
+import com.egobook.app.store.data.model.Price
 import com.egobook.app.ui.home.repository.UserRepository
 import io.mockk.coEvery
 import io.mockk.every
@@ -75,14 +78,22 @@ class StoreViewModelTest {
     @Test
     fun `initialize 성공 시 장착 아이템 목록을 반영한다`() = runTest {
         // Given
+        val expectedItems = listOf(
+            CustomItem(
+                id = "1",
+                type = ItemType.SKIN,
+                price = Price(100),
+                itemStatus = ItemStatus.PURCHASED
+            )
+        )
         coEvery { userRepository.load() } throws RuntimeException("ink load skipped for this test")
         coEvery { shopRepository.initialize() } returns Unit
-        coEvery { shopRepository.loadEquippedItems() } returns emptyList()
+        coEvery { shopRepository.loadEquippedItems() } returns expectedItems
 
         // When
         viewModel.initialize()
 
         // Then
-        assertEquals(emptyList<CustomItem>(), viewModel.equippedItems.value)
+        assertEquals(expectedItems, viewModel.equippedItems.value)
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
- 상점(에고룸 꾸미기) 화면 진입 시 토큰 만료 등 예외 상황에서 앱이 비정상 종료되던 문제 수정
- 주간 리포트 잉크 잠금 해제 시 실제 해제 API 호출이 주석 처리되어 있어 잉크만 소모되고 잠금은 풀리지 않던 문제 수정
- 주간 리포트 광고 보기 버튼이 미구현(TODO) 상태였던 것을 AdMob 리워드 광고 연동으로 구현
- 잠금 해제 API 응답의 data 필드 타입 불일치로 실제로는 성공했는데 "실패"로 잘못 표시되던 문제 수정
- 잠금 해제 다이얼로그와 목록 화면이 서로 다른 ViewModel 인스턴스를 사용해 목록이 갱신되지 않던 문제 수정
- 관련 안내 토스트를 기본 스킨에서 기존 커스텀 토스트 디자인으로 변경

## 🔗 관련 이슈
- Fix #112

## 📸 스크린샷
<img width="548" height="1202" alt="녹화_2026_08_08_00_45_44_484" src="https://github.com/user-attachments/assets/b8061bfd-62b6-4f44-928c-df216c3e59a6" />

영상에서는 쪼그라든 모양이지만 기존 토스트와 동일한 디자인으로 수정해두었습니다.

[![b.jpg](https://i.postimg.cc/Z58qLQB4/b.jpg)](https://postimg.cc/0zNxkc0B)

## ✅ 체크리스트
- [x] 관련 없는 변경사항 삭제 했는가? (불필요한 주석, 로그 등)
- [x] 테스트 여부 (Unit Test 등)
- [x] 커밋 목적에 맞게 유동적으로 추가하기...
