### PR TITLE
✨Feat - GA 도입 후 커스텀 이벤트 생성

### DIFF
--- a/app/src/main/java/com/egobook/app/analytics/AnalyticsEvent.kt
+++ b/app/src/main/java/com/egobook/app/analytics/AnalyticsEvent.kt
@@ -1,0 +1,65 @@
+package com.egobook.app.analytics
+
+/**
+ * Firebase 예약 이벤트(login, sign_up 등)는 [com.google.firebase.analytics.FirebaseAnalytics.Event]를
+ * 그대로 사용하고, 여기에는 커스텀 이벤트명만 정의한다.
+ */
+object AnalyticsEvent {
+
+    // A. 로그인/가입
+    const val ONBOARDING_COMPLETE = "onboarding_complete"
+
+    // B. 계정/상점/알림
+    const val ACCOUNT_LINK_START = "account_link_start"
+    const val ACCOUNT_LINK_COMPLETE = "account_link_complete"
+    const val ACCOUNT_WITHDRAW_REQUEST = "account_withdraw_request"
+    const val ACCOUNT_WITHDRAW_CONFIRM = "account_withdraw_confirm"
+    const val SHOP_OPEN = "shop_open"
+    const val SHOP_EXIT = "shop_exit"
+    const val ITEM_PURCHASE = "item_purchase"
+    const val ITEM_EQUIP = "item_equip"
+    const val NOTIFICATION_OPEN = "notification_open"
+    const val NOTIFICATION_TOGGLE = "notification_toggle"
+
+    // C. 메인페이지
+    const val NICKNAME_CHANGE = "nickname_change"
+    const val PSYCH_KNOWLEDGE_OPEN = "psych_knowledge_open"
+    const val PSYCH_KNOWLEDGE_SAVE = "psych_knowledge_save"
+    const val PSYCH_KNOWLEDGE_UNSAVE = "psych_knowledge_unsave"
+    const val LEVEL_UP = "level_up"
+    const val AD_REWARD_WATCH = "ad_reward_watch"
+
+    // D. 감정일기
+    const val DIARY_WRITE = "diary_write"
+    const val DIARY_EDIT = "diary_edit"
+    const val DIARY_DELETE = "diary_delete"
+    const val DIARY_EXPORT = "diary_export"
+    const val DIARY_CALENDAR_VIEW = "diary_calendar_view"
+
+    // E. 에고룸
+    const val PRAISE_LETTER_VIEW = "praise_letter_view"
+    const val PRAISE_LETTER_TOGGLE = "praise_letter_toggle"
+    const val WEEKLY_REPORT_UNLOCK = "weekly_report_unlock"
+    const val WEEKLY_REPORT_TONE_SELECT = "weekly_report_tone_select"
+    const val WEEKLY_REPORT_TOGGLE = "weekly_report_toggle"
+    const val STATS_VIEW = "stats_view"
+
+    // F. 광장/친구
+    const val LETTER_RECEIVE = "letter_receive"
+    const val LETTER_REPLY_SEND = "letter_reply_send"
+    const val LETTER_GIVE_UP = "letter_give_up"
+    const val LETTER_REPORT = "letter_report"
+    const val LETTER_SEND = "letter_send"
+    const val LETTER_DELETE = "letter_delete"
+    const val QUESTION_ANSWER_WRITE = "question_answer_write"
+    const val QUESTION_VIEW_ALL = "question_view_all"
+    const val QUESTION_ANSWER_EDIT = "question_answer_edit"
+    const val QUESTION_ANSWER_DELETE = "question_answer_delete"
+    const val FRIEND_REQUEST_SEND = "friend_request_send"
+    const val FRIEND_REQUEST_ACCEPT = "friend_request_accept"
+    const val FRIEND_REQUEST_REJECT = "friend_request_reject"
+    const val FRIEND_DELETE = "friend_delete"
+
+    // 스펙 표에는 없지만 기존 신고 기능과 대응되어 추가한 이벤트
+    const val QUESTION_ANSWER_REPORT = "question_answer_report"
+}

--- a/app/src/main/java/com/egobook/app/analytics/AnalyticsLogger.kt
+++ b/app/src/main/java/com/egobook/app/analytics/AnalyticsLogger.kt
@@ -1,0 +1,39 @@
+package com.egobook.app.analytics
+
+import android.os.Bundle
+import com.google.firebase.analytics.FirebaseAnalytics
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * 모든 Firebase Analytics 이벤트 로깅은 이 클래스를 통해서만 나가야 한다.
+ * 로깅 실패가 앱 로직에 영향을 주지 않도록 내부에서 예외를 전부 흡수한다.
+ */
+@Singleton
+class AnalyticsLogger @Inject constructor(
+    private val firebaseAnalytics: FirebaseAnalytics
+) {
+
+    fun logEvent(event: String, params: Map<String, Any?> = emptyMap()) {
+        try {
+            firebaseAnalytics.logEvent(event, params.toBundle())
+        } catch (e: Exception) {
+            Timber.e(e, "Analytics logEvent failed: $event")
+        }
+    }
+
+    private fun Map<String, Any?>.toBundle(): Bundle = Bundle().apply {
+        for ((key, value) in this@toBundle) {
+            when (value) {
+                null -> Unit
+                is String -> putString(key, value)
+                is Int -> putLong(key, value.toLong())
+                is Long -> putLong(key, value)
+                is Float -> putDouble(key, value.toDouble())
+                is Double -> putDouble(key, value)
+                else -> putString(key, value.toString())
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/egobook/app/analytics/AnalyticsParam.kt
+++ b/app/src/main/java/com/egobook/app/analytics/AnalyticsParam.kt
@@ -1,0 +1,28 @@
+package com.egobook.app.analytics
+
+/**
+ * Firebase 예약 파라미터(method 등)는 [com.google.firebase.analytics.FirebaseAnalytics.Param]을
+ * 그대로 사용하고, 여기에는 커스텀 파라미터명만 정의한다.
+ */
+object AnalyticsParam {
+    const val IS_FIRST_TODAY = "is_first_today"
+    const val STAT_TYPE = "stat_type"
+    const val NEW_LEVEL = "new_level"
+    const val AD_COUNT_TODAY = "ad_count_today"
+    const val MOOD_LEVEL = "mood_level"
+    const val HAS_WORRY = "has_worry"
+    const val HAS_GRATITUDE = "has_gratitude"
+    const val HAS_PRAISE = "has_praise"
+    const val FORMAT = "format"
+    const val DATE_RANGE_DAYS = "date_range_days"
+    const val ENABLED = "enabled"
+    const val TONE = "tone"
+    const val FROM_TYPE = "from_type"
+    const val REASON = "reason"
+    const val TARGET_TYPE = "target_type"
+    const val VISIBILITY = "visibility"
+    const val ITEM_ID = "item_id"
+    const val ITEM_TYPE = "item_type"
+    const val PRICE = "price"
+    const val NOTIFICATION_TYPE = "notification_type"
+}

--- a/app/src/main/java/com/egobook/app/di/module/AnalyticsModule.kt
+++ b/app/src/main/java/com/egobook/app/di/module/AnalyticsModule.kt
@@ -1,0 +1,21 @@
+package com.egobook.app.di.module
+
+import android.content.Context
+import com.google.firebase.analytics.FirebaseAnalytics
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AnalyticsModule {
+
+    @Provides
+    @Singleton
+    fun provideFirebaseAnalytics(
+        @ApplicationContext context: Context
+    ): FirebaseAnalytics = FirebaseAnalytics.getInstance(context)
+}

--- a/app/src/main/java/com/egobook/app/store/ui/StoreFragment.kt
+++ b/app/src/main/java/com/egobook/app/store/ui/StoreFragment.kt
@@ -65,6 +65,9 @@ class StoreFragment: Fragment() {
             viewModel.initialize()
         }
 
+        if (savedInstanceState == null) {
+            viewModel.logShopOpen()
+        }
         viewModel.loadInk()
         viewPager = binding.vp2StoreCollectionContainer
         viewPager.adapter = StoreCollectionAdapter(this)

--- a/app/src/main/java/com/egobook/app/store/ui/StoreLeavingDialog.kt
+++ b/app/src/main/java/com/egobook/app/store/ui/StoreLeavingDialog.kt
@@ -40,6 +40,7 @@ class StoreLeavingDialog: DialogFragment() {
         binding.btnLeave.setOnClickListener {
             removeScreenBlur()
             dismiss()
+            viewModel.logShopExit()
             // viewModel.resetEquipItems()
             findNavController().navigate(R.id.action_storeFragment_to_homeFragment)
         }

--- a/app/src/main/java/com/egobook/app/store/ui/StoreViewModel.kt
+++ b/app/src/main/java/com/egobook/app/store/ui/StoreViewModel.kt
@@ -3,6 +3,9 @@ package com.egobook.app.store.ui
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.egobook.app.analytics.AnalyticsEvent
+import com.egobook.app.analytics.AnalyticsLogger
+import com.egobook.app.analytics.AnalyticsParam
 import com.egobook.app.store.data.ShopRepository
 import com.egobook.app.store.data.local.LocalShopDataSource
 import com.egobook.app.store.data.model.ItemStatus
@@ -31,8 +34,17 @@ data class CustomItemState(
 @HiltViewModel
 class StoreViewModel @Inject constructor(
     private val shopRepository: ShopRepository,
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
+    private val analyticsLogger: AnalyticsLogger
 ) : ViewModel() {
+
+    fun logShopOpen() {
+        analyticsLogger.logEvent(AnalyticsEvent.SHOP_OPEN)
+    }
+
+    fun logShopExit() {
+        analyticsLogger.logEvent(AnalyticsEvent.SHOP_EXIT)
+    }
 
     private var loadingCount = 0
     private val _isLoading = MutableStateFlow(false)
@@ -161,6 +173,13 @@ class StoreViewModel @Inject constructor(
                     val updatedEquipped = shopRepository.equipItemPermanently(item, !isAlreadyEquipped)
                     _permanentItems.value = updatedEquipped
                     _equippedItems.value = updatedEquipped
+                    analyticsLogger.logEvent(
+                        AnalyticsEvent.ITEM_EQUIP,
+                        mapOf(
+                            AnalyticsParam.ITEM_ID to item.id,
+                            AnalyticsParam.ITEM_TYPE to item.type.name
+                        )
+                    )
                     Log.d("StoreViewModel", "서버 착용 상태 변경 성공: ${item.id}, ${!isAlreadyEquipped}")
                 } catch (e: Exception) {
                     Log.e("StoreViewModel", "서버 통신 에러", e)
@@ -198,6 +217,14 @@ class StoreViewModel @Inject constructor(
                 loadInk()
                 // 구매 성공 후 최신 장착 정보 다시 로드
                 loadEquippedItems()
+                analyticsLogger.logEvent(
+                    AnalyticsEvent.ITEM_PURCHASE,
+                    mapOf(
+                        AnalyticsParam.ITEM_ID to item.id,
+                        AnalyticsParam.ITEM_TYPE to item.type.name,
+                        AnalyticsParam.PRICE to item.price.value
+                    )
+                )
                 _toastEvent.emit("구매가 완료되었어요")
             } catch (e: Exception) {
                 Log.e("StoreViewModel", "Purchase failed", e)

--- a/app/src/main/java/com/egobook/app/ui/account/viewmodel/AccountViewModel.kt
+++ b/app/src/main/java/com/egobook/app/ui/account/viewmodel/AccountViewModel.kt
@@ -2,6 +2,8 @@ package com.egobook.app.ui.account.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.egobook.app.analytics.AnalyticsEvent
+import com.egobook.app.analytics.AnalyticsLogger
 import com.egobook.app.domain.model.account.NicknameValidationResult
 import com.egobook.app.domain.model.account.NicknameValidator
 import com.egobook.app.domain.repository.account.AccountRepository
@@ -19,7 +21,8 @@ import com.egobook.app.domain.model.auth.AuthError
 @HiltViewModel
 class AccountViewModel @Inject constructor(
     private val accountRepository: AccountRepository,
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
+    private val analyticsLogger: AnalyticsLogger
 ) : ViewModel() {
         private val _userIdState = MutableStateFlow<UiState<String>>(UiState.Idle)
         val userIdState = _userIdState.asStateFlow()
@@ -80,10 +83,12 @@ class AccountViewModel @Inject constructor(
     fun linkToGoogle(idToken: String) {
         viewModelScope.launch {
             _linkState.value = UiState.Loading
+            analyticsLogger.logEvent(AnalyticsEvent.ACCOUNT_LINK_START)
 
             accountRepository.linkToGoogle(idToken)
                 .onSuccess {
                     _linkState.value = UiState.Success(Unit)
+                    analyticsLogger.logEvent(AnalyticsEvent.ACCOUNT_LINK_COMPLETE)
                     _linkToastEvent.emit("Google 계정 연동이 완료되었습니다!")
 
                     // 연동 성공 후 userId 갱신
@@ -138,6 +143,7 @@ class AccountViewModel @Inject constructor(
                 .onSuccess {
                     _nickname.value = nickname
                     _nicknameUpdateState.value = UiState.Success(Unit)
+                    analyticsLogger.logEvent(AnalyticsEvent.NICKNAME_CHANGE)
                     _nicknameToastEvent.emit("닉네임이 변경되었습니다.")
                 }
                 .onFailure { e ->
@@ -154,10 +160,12 @@ class AccountViewModel @Inject constructor(
     fun deleteAccount() {
         viewModelScope.launch {
             _deleteAccountState.value = UiState.Loading
+            analyticsLogger.logEvent(AnalyticsEvent.ACCOUNT_WITHDRAW_REQUEST)
 
             accountRepository.deleteAccount()
                 .onSuccess {
                     _deleteAccountState.value = UiState.Success(Unit)
+                    analyticsLogger.logEvent(AnalyticsEvent.ACCOUNT_WITHDRAW_CONFIRM)
                 }
                 .onFailure { e ->
                     _deleteAccountState.value =

--- a/app/src/main/java/com/egobook/app/ui/counseling/viewmodel/DailyPraiseViewModel.kt
+++ b/app/src/main/java/com/egobook/app/ui/counseling/viewmodel/DailyPraiseViewModel.kt
@@ -5,6 +5,9 @@ import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import androidx.paging.map
+import com.egobook.app.analytics.AnalyticsEvent
+import com.egobook.app.analytics.AnalyticsLogger
+import com.egobook.app.analytics.AnalyticsParam
 import com.egobook.app.domain.usecase.egoroom.GetDailyAndWeeklyNotificationUseCase
 import com.egobook.app.domain.usecase.egoroom.GetDailyPraiseByDateUseCase
 import com.egobook.app.domain.usecase.egoroom.GetDailyPraiseUseCase
@@ -28,7 +31,8 @@ class DailyPraiseViewModel @Inject constructor(
     private val getDailyPraiseUseCase: GetDailyPraiseUseCase,
     private val getDailyPraiseByDateUseCase: GetDailyPraiseByDateUseCase,
     private val getDailyAndWeeklyNotificationUseCase: GetDailyAndWeeklyNotificationUseCase,
-    private val updateDailyPraiseNotificationUseCase: UpdateDailyPraiseNotificationUseCase
+    private val updateDailyPraiseNotificationUseCase: UpdateDailyPraiseNotificationUseCase,
+    private val analyticsLogger: AnalyticsLogger
 ): ViewModel() {
 
     private val _dailyPraiseList = MutableStateFlow<PagingData<PraiseDailyModel>>(PagingData.empty())
@@ -49,6 +53,7 @@ class DailyPraiseViewModel @Inject constructor(
         viewModelScope.launch {
             _dailyPraiseByDate.emit(UiState.Loading)
             getDailyPraiseByDateUseCase(date = date).onSuccess { domain ->
+                analyticsLogger.logEvent(AnalyticsEvent.PRAISE_LETTER_VIEW)
                 _dailyPraiseByDate.emit(UiState.Success(domain.toPresentation()))
             }.onFailure { error ->
                 _dailyPraiseByDate.emit(UiState.Failure(error.message))
@@ -77,6 +82,10 @@ class DailyPraiseViewModel @Inject constructor(
         viewModelScope.launch {
             _updateNotificationStatus.emit(UiState.Loading)
             updateDailyPraiseNotificationUseCase(isEnabled = isEnabled).onSuccess { isEnabled ->
+                analyticsLogger.logEvent(
+                    AnalyticsEvent.PRAISE_LETTER_TOGGLE,
+                    mapOf(AnalyticsParam.ENABLED to isEnabled)
+                )
                 _updateNotificationStatus.emit(UiState.Success(isEnabled))
             }.onFailure { error ->
                 _updateNotificationStatus.emit(UiState.Failure(error.message))

--- a/app/src/main/java/com/egobook/app/ui/counseling/viewmodel/StatisticsViewModel.kt
+++ b/app/src/main/java/com/egobook/app/ui/counseling/viewmodel/StatisticsViewModel.kt
@@ -2,6 +2,8 @@ package com.egobook.app.ui.counseling.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.egobook.app.analytics.AnalyticsEvent
+import com.egobook.app.analytics.AnalyticsLogger
 import com.egobook.app.domain.usecase.GetStatisticsUseCase
 import com.egobook.app.ui.counseling.model.StatisticsModel
 import com.egobook.app.ui.counseling.model.toPresentation
@@ -13,7 +15,10 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class StatisticsViewModel @Inject constructor(private val useCase: GetStatisticsUseCase): ViewModel() {
+class StatisticsViewModel @Inject constructor(
+    private val useCase: GetStatisticsUseCase,
+    private val analyticsLogger: AnalyticsLogger
+): ViewModel() {
 
     private val _statisticsInfo = MutableStateFlow<UiState<StatisticsModel>>(UiState.Idle)
     val statisticsInfo = _statisticsInfo.asStateFlow()
@@ -21,6 +26,7 @@ class StatisticsViewModel @Inject constructor(private val useCase: GetStatistics
     fun fetchStatistics() {
         viewModelScope.launch {
             _statisticsInfo.value = UiState.Loading
+            analyticsLogger.logEvent(AnalyticsEvent.STATS_VIEW)
             useCase().onSuccess { domain ->
                 _statisticsInfo.value = UiState.Success(domain.toPresentation())
             }.onFailure { error ->

--- a/app/src/main/java/com/egobook/app/ui/counseling/viewmodel/WeeklyReportViewModel.kt
+++ b/app/src/main/java/com/egobook/app/ui/counseling/viewmodel/WeeklyReportViewModel.kt
@@ -5,6 +5,9 @@ import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import androidx.paging.map
+import com.egobook.app.analytics.AnalyticsEvent
+import com.egobook.app.analytics.AnalyticsLogger
+import com.egobook.app.analytics.AnalyticsParam
 import com.egobook.app.domain.model.ReportStyle
 import com.egobook.app.domain.model.counseling.WeeklyReportUnlockType
 import com.egobook.app.domain.usecase.GetUserInfoUseCase
@@ -22,6 +25,7 @@ import com.egobook.app.ui.counseling.model.WeeklyReportStyleModel
 import com.egobook.app.ui.counseling.model.toPresentation
 import com.egobook.app.ui.home.user.User
 import com.egobook.app.util.UiState
+import com.google.firebase.analytics.FirebaseAnalytics
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -40,7 +44,8 @@ class WeeklyReportViewModel @Inject constructor(
     private val updateWeeklyReportNotificationUseCase: UpdateWeeklyReportNotificationUseCase,
     private val getWeeklyReportByDateUseCase: GetWeeklyReportByDateUseCase,
     private val unlockWeeklyReportUseCase: UnlockWeeklyReportUseCase,
-    private val getUserInfoUseCase: GetUserInfoUseCase
+    private val getUserInfoUseCase: GetUserInfoUseCase,
+    private val analyticsLogger: AnalyticsLogger
 ): ViewModel() {
 
     private val _weeklyReportList = MutableStateFlow<PagingData<WeeklyReportModel>>(PagingData.empty())
@@ -74,6 +79,10 @@ class WeeklyReportViewModel @Inject constructor(
     fun updateWeeklyReportNotification(isEnabled: Boolean) {
         viewModelScope.launch {
             updateWeeklyReportNotificationUseCase(isEnabled = isEnabled).onSuccess { isEnabled ->
+                analyticsLogger.logEvent(
+                    AnalyticsEvent.WEEKLY_REPORT_TOGGLE,
+                    mapOf(AnalyticsParam.ENABLED to isEnabled)
+                )
                 _updateNotificationStatus.emit(UiState.Success(isEnabled))
             }.onFailure { error ->
                 _updateNotificationStatus.emit(UiState.Failure(error.message))
@@ -115,6 +124,10 @@ class WeeklyReportViewModel @Inject constructor(
         viewModelScope.launch {
             _updateReportStyleResult.emit(UiState.Loading)
             updateWeeklyReportStyleUseCase(reportStyle = reportStyle).onSuccess { reportStyle ->
+                analyticsLogger.logEvent(
+                    AnalyticsEvent.WEEKLY_REPORT_TONE_SELECT,
+                    mapOf(AnalyticsParam.TONE to reportStyle.value)
+                )
                 _updateReportStyleResult.emit( UiState.Success(reportStyle))
             }.onFailure { error ->
                 _updateReportStyleResult.emit( UiState.Failure(error.message))
@@ -129,6 +142,10 @@ class WeeklyReportViewModel @Inject constructor(
         viewModelScope.launch {
             _unlockWeeklyReportResult.emit(UiState.Loading)
             unlockWeeklyReportUseCase(startDate = startDate, unlockType = unlockType).onSuccess {
+                analyticsLogger.logEvent(
+                    AnalyticsEvent.WEEKLY_REPORT_UNLOCK,
+                    mapOf(FirebaseAnalytics.Param.METHOD to unlockType.value.lowercase())
+                )
                 _unlockWeeklyReportResult.emit(UiState.Success(it))
             }.onFailure { error ->
                 _unlockWeeklyReportResult.emit(UiState.Failure(error.message))

--- a/app/src/main/java/com/egobook/app/ui/diary/view/CalenderFragment.kt
+++ b/app/src/main/java/com/egobook/app/ui/diary/view/CalenderFragment.kt
@@ -74,6 +74,7 @@ class CalenderFragment : Fragment() {
         
         // 2. 초기 월 데이터 로드 (스와이프 시 자동 호출되지만 초기 진입 시 한 번은 직접 호출)
         viewModel.setYearMonth(initialMonth)
+        viewModel.logCalendarView()
         
         // 2. observing 시작
         observeViewModel()

--- a/app/src/main/java/com/egobook/app/ui/diary/viewmodel/CalenderViewModel.kt
+++ b/app/src/main/java/com/egobook/app/ui/diary/viewmodel/CalenderViewModel.kt
@@ -2,6 +2,8 @@ package com.egobook.app.ui.diary.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.egobook.app.analytics.AnalyticsEvent
+import com.egobook.app.analytics.AnalyticsLogger
 import com.egobook.app.domain.model.calender.CalenderDate
 import com.egobook.app.domain.usecase.CalenderUseCases
 import com.egobook.app.ui.diary.mapper.CalenderEntityMapper
@@ -19,8 +21,13 @@ import android.util.Log
 
 @HiltViewModel
 class CalenderViewModel @Inject constructor(
-    private val calenderUseCases: CalenderUseCases
+    private val calenderUseCases: CalenderUseCases,
+    private val analyticsLogger: AnalyticsLogger
 ) : ViewModel() {
+
+    fun logCalendarView() {
+        analyticsLogger.logEvent(AnalyticsEvent.DIARY_CALENDAR_VIEW)
+    }
 
     private val _state = MutableStateFlow(CalenderState())
     val state: StateFlow<CalenderState> = _state.asStateFlow()

--- a/app/src/main/java/com/egobook/app/ui/diary/viewmodel/DiariesViewModel.kt
+++ b/app/src/main/java/com/egobook/app/ui/diary/viewmodel/DiariesViewModel.kt
@@ -5,6 +5,9 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
+import com.egobook.app.analytics.AnalyticsEvent
+import com.egobook.app.analytics.AnalyticsLogger
+import com.egobook.app.analytics.AnalyticsParam
 import com.egobook.app.domain.model.diary.entity.DiaryFilter
 import com.egobook.app.domain.model.diary.entity.DiarySummary
 import com.egobook.app.domain.model.diary.entity.DiaryType
@@ -27,7 +30,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class DiariesViewModel @Inject constructor(
-    private val diaryUseCases: DiaryUseCases
+    private val diaryUseCases: DiaryUseCases,
+    private val analyticsLogger: AnalyticsLogger
 ) : ViewModel() {
     private val _state = MutableStateFlow(DiariesState())  // 뷰모델 내부 갱신용
     val state = _state.asStateFlow()    // 외부(ui) 읽기 전용
@@ -104,6 +108,14 @@ class DiariesViewModel @Inject constructor(
         viewModelScope.launch {
             diaryUseCases.exportDiary(form)
                 .onSuccess {
+                    analyticsLogger.logEvent(
+                        AnalyticsEvent.DIARY_EXPORT,
+                        mapOf(
+                            AnalyticsParam.FORMAT to form.format,
+                            AnalyticsParam.DATE_RANGE_DAYS to
+                                (java.time.temporal.ChronoUnit.DAYS.between(form.startDate, form.endDate) + 1)
+                        )
+                    )
                     _downloadUrl.emit(it.fileUrl)
                 }
                 .onFailure {

--- a/app/src/main/java/com/egobook/app/ui/diary/viewmodel/DiaryCheckViewModel.kt
+++ b/app/src/main/java/com/egobook/app/ui/diary/viewmodel/DiaryCheckViewModel.kt
@@ -3,6 +3,8 @@ package com.egobook.app.ui.diary.viewmodel
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.egobook.app.analytics.AnalyticsEvent
+import com.egobook.app.analytics.AnalyticsLogger
 import com.egobook.app.domain.model.diary.entity.Diary
 import com.egobook.app.domain.usecase.diaryusecase.DiaryUseCases
 import com.egobook.app.util.UiState
@@ -15,7 +17,8 @@ import javax.inject.Inject
 @HiltViewModel
 class DiaryCheckViewModel @Inject constructor(
     private val diaryUseCases: DiaryUseCases,
-    private val savedStateHandle: SavedStateHandle
+    private val savedStateHandle: SavedStateHandle,
+    private val analyticsLogger: AnalyticsLogger
 ) : ViewModel() {
 
     private val _diaryState = MutableStateFlow<UiState<Diary>>(UiState.Loading)
@@ -61,6 +64,7 @@ class DiaryCheckViewModel @Inject constructor(
         viewModelScope.launch {
             diaryUseCases.deleteDiary(diaryId)
                 .onSuccess {
+                    analyticsLogger.logEvent(AnalyticsEvent.DIARY_DELETE)
                     _deleteSuccess.value = true
                 }
                 .onFailure {

--- a/app/src/main/java/com/egobook/app/ui/diary/viewmodel/DiaryWriteViewModel.kt
+++ b/app/src/main/java/com/egobook/app/ui/diary/viewmodel/DiaryWriteViewModel.kt
@@ -4,6 +4,9 @@ import androidx.compose.ui.focus.FocusState
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.egobook.app.analytics.AnalyticsEvent
+import com.egobook.app.analytics.AnalyticsLogger
+import com.egobook.app.analytics.AnalyticsParam
 import com.egobook.app.domain.usecase.diaryusecase.DiaryUseCases
 import com.egobook.app.ui.diary.mapper.DiaryEntityMapper
 import com.egobook.app.ui.diary.model.ToastMessage
@@ -22,7 +25,8 @@ import javax.inject.Inject
 @HiltViewModel
 class DiaryWriteViewModel @Inject constructor(
     private val diaryUseCases: DiaryUseCases,
-    private val savedStateHandle: SavedStateHandle
+    private val savedStateHandle: SavedStateHandle,
+    private val analyticsLogger: AnalyticsLogger
 ) : ViewModel() {
     
     private val _selectedDate = MutableStateFlow<LocalDate>(LocalDate.now())
@@ -192,6 +196,7 @@ class DiaryWriteViewModel @Inject constructor(
             diaryId = diaryId,
             diary = updatedDiary
         ).onSuccess {
+            analyticsLogger.logEvent(AnalyticsEvent.DIARY_EDIT)
             _saveResult.emit(SaveResult.Success(emptyList()))
         }.onFailure { error ->
             _saveResult.emit(SaveResult.Error(error.message))
@@ -216,6 +221,15 @@ class DiaryWriteViewModel @Inject constructor(
 
         diaryUseCases.addDiary(newDiary)
             .onSuccess { rewards ->
+                analyticsLogger.logEvent(
+                    AnalyticsEvent.DIARY_WRITE,
+                    mapOf(
+                        AnalyticsParam.MOOD_LEVEL to newDiary.emotionLevel,
+                        AnalyticsParam.HAS_WORRY to state.selectedTypes.contains("고민"),
+                        AnalyticsParam.HAS_GRATITUDE to state.selectedTypes.contains("감사"),
+                        AnalyticsParam.HAS_PRAISE to state.selectedTypes.contains("칭찬")
+                    )
+                )
                 val messages = DiaryEntityMapper.createToastMessages(rewards)
                 _saveResult.emit(SaveResult.Success(messages))
             }.onFailure { error ->

--- a/app/src/main/java/com/egobook/app/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/egobook/app/ui/home/HomeViewModel.kt
@@ -3,6 +3,9 @@ package com.egobook.app.ui.home
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.egobook.app.analytics.AnalyticsEvent
+import com.egobook.app.analytics.AnalyticsLogger
+import com.egobook.app.analytics.AnalyticsParam
 import com.egobook.app.ui.home.repository.AdInfoDto
 import com.egobook.app.ui.home.repository.UserAdRepository
 import com.egobook.app.ui.home.repository.UserPsychologyRepository
@@ -27,7 +30,8 @@ class HomeViewModel @Inject constructor(
     private val userAdRepository: UserAdRepository,
     private val psychologyRepository: UserPsychologyRepository,
     private val shopRepository: ShopRepository,
-    private val userTendencyRepository: UserTendencyRepository
+    private val userTendencyRepository: UserTendencyRepository,
+    private val analyticsLogger: AnalyticsLogger
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(User(id=-1, Level(1),Ink(0), nickname = ""))
     val uiState: StateFlow<User> = _uiState.asStateFlow()
@@ -99,8 +103,21 @@ class HomeViewModel @Inject constructor(
 
     private suspend fun fetchTendenciesInternal() {
         try {
+            val previousTendencies = _tendencies.value
             val tendencyList = userTendencyRepository.loadTendencies()
             _tendencies.value = tendencyList
+            tendencyList.forEach { updated ->
+                val previous = previousTendencies.find { it.type == updated.type }
+                if (previous != null && updated.level > previous.level) {
+                    analyticsLogger.logEvent(
+                        AnalyticsEvent.LEVEL_UP,
+                        mapOf(
+                            AnalyticsParam.STAT_TYPE to updated.type.name,
+                            AnalyticsParam.NEW_LEVEL to updated.level
+                        )
+                    )
+                }
+            }
         } catch (error: Exception) {
             Log.e("HomeViewModel", "Failed to fetch tendencies", error)
         }
@@ -168,12 +185,26 @@ class HomeViewModel @Inject constructor(
         }
     }
 
+    fun logPsychKnowledgeOpen() {
+        // 이 진입점(홈의 오늘의 병 아이콘)은 당일 미열람 상태일 때만 노출되므로 항상 최초 오픈이다.
+        analyticsLogger.logEvent(
+            AnalyticsEvent.PSYCH_KNOWLEDGE_OPEN,
+            mapOf(AnalyticsParam.IS_FIRST_TODAY to true)
+        )
+    }
+
     fun watchAd() {
         viewModelScope.launch {
             showLoading()
             try {
                 val message = userAdRepository.watchAd()
                 fetchUserInternal()
+                val freshAdCount = runCatching { userAdRepository.loadAdInfo().currentViewCount }
+                    .getOrDefault(_adState.value.currentViewCount + 1)
+                analyticsLogger.logEvent(
+                    AnalyticsEvent.AD_REWARD_WATCH,
+                    mapOf(AnalyticsParam.AD_COUNT_TODAY to freshAdCount)
+                )
                 Log.d("HomeViewModel", "Ad watched: $message")
             } finally {
                 hideLoading()

--- a/app/src/main/java/com/egobook/app/ui/home/NotificationViewModel.kt
+++ b/app/src/main/java/com/egobook/app/ui/home/NotificationViewModel.kt
@@ -3,6 +3,9 @@ package com.egobook.app.ui.home
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.egobook.app.analytics.AnalyticsEvent
+import com.egobook.app.analytics.AnalyticsLogger
+import com.egobook.app.analytics.AnalyticsParam
 import com.egobook.app.ui.home.notification.Notification
 import com.egobook.app.ui.home.repository.HomeNotificationRepository
 import com.egobook.app.ui.home.repository.NotificationSettingDto
@@ -15,7 +18,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class NotificationViewModel @Inject constructor(
-    private val repository: HomeNotificationRepository
+    private val repository: HomeNotificationRepository,
+    private val analyticsLogger: AnalyticsLogger
 ): ViewModel() {
 
     private val _notifications = MutableStateFlow<List<Notification>>(emptyList())
@@ -57,6 +61,10 @@ class NotificationViewModel @Inject constructor(
             val notificationSetting = repository.changeNotificationSetting()
             Log.d("jang", "${notificationSetting}")
             _notificationSettingState.value = notificationSetting
+            analyticsLogger.logEvent(
+                AnalyticsEvent.NOTIFICATION_TOGGLE,
+                mapOf(AnalyticsParam.ENABLED to notificationSetting.enabled)
+            )
         }
     }
 
@@ -64,6 +72,10 @@ class NotificationViewModel @Inject constructor(
         viewModelScope.launch {
             val notificationReadingDto = repository.readNotification(notification)
             Log.d("jang", "${notificationReadingDto}")
+            analyticsLogger.logEvent(
+                AnalyticsEvent.NOTIFICATION_OPEN,
+                mapOf(AnalyticsParam.NOTIFICATION_TYPE to (notification.type::class.simpleName ?: "unknown"))
+            )
             loadNotifications()
         }
     }

--- a/app/src/main/java/com/egobook/app/ui/home/PsychologyViewModel.kt
+++ b/app/src/main/java/com/egobook/app/ui/home/PsychologyViewModel.kt
@@ -2,6 +2,8 @@ package com.egobook.app.ui.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.egobook.app.analytics.AnalyticsEvent
+import com.egobook.app.analytics.AnalyticsLogger
 import com.egobook.app.ui.home.repository.DailyPsychologyDto
 import com.egobook.app.ui.home.repository.PsychologyKnowledge
 import com.egobook.app.ui.home.repository.PsychologyReward
@@ -16,7 +18,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class PsychologyViewModel @Inject constructor(
-    private val psychologyRepository: UserPsychologyRepository
+    private val psychologyRepository: UserPsychologyRepository,
+    private val analyticsLogger: AnalyticsLogger
 ) : ViewModel() {
 
     private var loadingCount = 0
@@ -109,6 +112,7 @@ class PsychologyViewModel @Inject constructor(
             showLoading()
             try {
                 psychologyRepository.saveDailyPsychology(knowledgeId)
+                analyticsLogger.logEvent(AnalyticsEvent.PSYCH_KNOWLEDGE_SAVE)
                 fetchDailyPsychologyInternal()
                 fetchSavedPsychologyInternal()
             } finally {
@@ -122,6 +126,7 @@ class PsychologyViewModel @Inject constructor(
             showLoading()
             try {
                 psychologyRepository.deletePsychology(knowledgeId)
+                analyticsLogger.logEvent(AnalyticsEvent.PSYCH_KNOWLEDGE_UNSAVE)
                 fetchDailyPsychologyInternal()
                 fetchSavedPsychologyInternal()
             } finally {

--- a/app/src/main/java/com/egobook/app/ui/home/ui/HomeFragment.kt
+++ b/app/src/main/java/com/egobook/app/ui/home/ui/HomeFragment.kt
@@ -93,6 +93,7 @@ class HomeFragment(): Fragment() {
             dialog.isCancelable = false
             dialog.show(parentFragmentManager, "DailyPsychologyDialog")
             binding.ivDailyBottle.visibility = View.INVISIBLE
+            viewModel.logPsychKnowledgeOpen()
 
             parentFragmentManager.setFragmentResultListener("psychology_key", viewLifecycleOwner) { _, _ ->
                 Log.d("jang", "다이얼로그 닫힘 감지 - 데이터 갱신")

--- a/app/src/main/java/com/egobook/app/ui/login/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/com/egobook/app/ui/login/viewmodel/LoginViewModel.kt
@@ -2,9 +2,11 @@ package com.egobook.app.ui.login.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.egobook.app.analytics.AnalyticsLogger
 import com.egobook.app.data.local.UserInfoStorage
 import com.egobook.app.domain.model.auth.AuthError
 import com.egobook.app.domain.usecase.authusecase.AuthUseCases
+import com.google.firebase.analytics.FirebaseAnalytics
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -20,6 +22,7 @@ import javax.inject.Inject
 class LoginViewModel @Inject constructor(
     private val authUseCases: AuthUseCases,
     private val userInfoStorage: UserInfoStorage,
+    private val analyticsLogger: AnalyticsLogger,
 ) : ViewModel()  {
     private val _isFirstSignUp = MutableSharedFlow<Unit>()
     val isFirstSignUp = _isFirstSignUp.asSharedFlow()
@@ -65,6 +68,10 @@ class LoginViewModel @Inject constructor(
                     authUseCases.googleSignUp(event.idToken)
                         .fold(
                             onSuccess = {
+                                analyticsLogger.logEvent(
+                                    FirebaseAnalytics.Event.SIGN_UP,
+                                    mapOf(FirebaseAnalytics.Param.METHOD to "google")
+                                )
                                 _isFirstSignUp.emit(Unit)
                                 _loginState.value = LoginState.Idle
                             },
@@ -85,6 +92,10 @@ class LoginViewModel @Inject constructor(
 
                     result.fold(
                         onSuccess = {
+                            analyticsLogger.logEvent(
+                                FirebaseAnalytics.Event.LOGIN,
+                                mapOf(FirebaseAnalytics.Param.METHOD to "google")
+                            )
                             _loginState.value = LoginState.Success
 
                         },
@@ -116,9 +127,17 @@ class LoginViewModel @Inject constructor(
                     result.fold(
                         onSuccess = {
                             if (loginType == UserInfoStorage.LoginType.GUEST) {
+                                analyticsLogger.logEvent(
+                                    FirebaseAnalytics.Event.LOGIN,
+                                    mapOf(FirebaseAnalytics.Param.METHOD to "guest")
+                                )
                                 _loginState.value = LoginState.Success  // 재로그인 성공 -> 메인으로
                                 Timber.d("재로그인 성공, 토큰 재발급")
                             } else {
+                                analyticsLogger.logEvent(
+                                    FirebaseAnalytics.Event.SIGN_UP,
+                                    mapOf(FirebaseAnalytics.Param.METHOD to "guest")
+                                )
                                 _isGuestSignUp.emit(Unit)  // 최초 로그인 -> 온보딩으로
                                 _loginState.value = LoginState.Idle
                                 Timber.d("회원가입 성공, 토큰 발급")

--- a/app/src/main/java/com/egobook/app/ui/onboarding/view/OnboardingActivity.kt
+++ b/app/src/main/java/com/egobook/app/ui/onboarding/view/OnboardingActivity.kt
@@ -7,12 +7,20 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import com.egobook.app.MainActivity
+import com.egobook.app.analytics.AnalyticsEvent
+import com.egobook.app.analytics.AnalyticsLogger
 import com.egobook.app.databinding.ActivityOnboardingBinding
 import com.egobook.app.ui.onboarding.adapter.OnboardingVPAdapter
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class OnboardingActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityOnboardingBinding
+
+    @Inject
+    lateinit var analyticsLogger: AnalyticsLogger
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -39,6 +47,7 @@ class OnboardingActivity : AppCompatActivity() {
 
     // OnboardingFifthFragment에서 호출할 메서드
     fun navigateToMainActivity() {
+        analyticsLogger.logEvent(AnalyticsEvent.ONBOARDING_COMPLETE)
         val intent = Intent(this, MainActivity::class.java)
         startActivity(intent)
         finish() // 온보딩 액티비티 종료

--- a/app/src/main/java/com/egobook/app/ui/square/viewmodel/FriendsViewModel.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/viewmodel/FriendsViewModel.kt
@@ -2,6 +2,8 @@ package com.egobook.app.ui.square.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.egobook.app.analytics.AnalyticsEvent
+import com.egobook.app.analytics.AnalyticsLogger
 import com.egobook.app.domain.usecase.AcceptFriendRequestUseCase
 import com.egobook.app.domain.usecase.CancelFriendRequestUseCase
 import com.egobook.app.domain.usecase.DeleteFriendUseCase
@@ -36,7 +38,8 @@ class FriendsViewModel @Inject constructor(
     private val rejectFriendRequestUseCase: RejectFriendRequestUseCase,
     private val acceptFriendRequestUseCase: AcceptFriendRequestUseCase,
     private val cancelFriendRequestUseCase: CancelFriendRequestUseCase,
-    private val getUserIdUseCase: GetUserIdUseCase
+    private val getUserIdUseCase: GetUserIdUseCase,
+    private val analyticsLogger: AnalyticsLogger
 ): ViewModel() {
 
     private val _friendList = MutableStateFlow<UiState<FriendListModel>>(UiState.Idle)
@@ -59,6 +62,7 @@ class FriendsViewModel @Inject constructor(
         viewModelScope.launch {
             _deleteFriendResult.emit(UiState.Loading)
             deleteFriendUseCase(deleteId = deleteId).onSuccess {
+                analyticsLogger.logEvent(AnalyticsEvent.FRIEND_DELETE)
                 _deleteFriendResult.emit(UiState.Success(it))
             }.onFailure { error ->
                 _deleteFriendResult.emit(UiState.Failure(error.message))
@@ -123,6 +127,7 @@ class FriendsViewModel @Inject constructor(
         viewModelScope.launch {
             _requestFriendshipResult.emit(UiState.Loading)
             requestFriendshipUseCase(receiverId = receiverId).onSuccess {
+                analyticsLogger.logEvent(AnalyticsEvent.FRIEND_REQUEST_SEND)
                 _requestFriendshipResult.emit(UiState.Success(it))
             }.onFailure { error ->
                 _requestFriendshipResult.emit(UiState.Failure(error.message))
@@ -137,6 +142,7 @@ class FriendsViewModel @Inject constructor(
         viewModelScope.launch {
             _rejectFriendRequestResult.emit(UiState.Loading)
             rejectFriendRequestUseCase(requestId = requestId).onSuccess { requestId ->
+                analyticsLogger.logEvent(AnalyticsEvent.FRIEND_REQUEST_REJECT)
                 _rejectFriendRequestResult.emit(UiState.Success(requestId))
             }.onFailure { error ->
                 _rejectFriendRequestResult.emit(UiState.Failure(error.message))
@@ -151,6 +157,7 @@ class FriendsViewModel @Inject constructor(
         viewModelScope.launch {
             _acceptFriendRequestResult.emit(UiState.Loading)
             acceptFriendRequestUseCase(requestId = requestId).onSuccess { requestId ->
+                analyticsLogger.logEvent(AnalyticsEvent.FRIEND_REQUEST_ACCEPT)
                 _acceptFriendRequestResult.emit(UiState.Success(requestId))
             }.onFailure { error ->
                 _acceptFriendRequestResult.emit(UiState.Failure(error.message))

--- a/app/src/main/java/com/egobook/app/ui/square/viewmodel/LetterViewModel.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/viewmodel/LetterViewModel.kt
@@ -5,6 +5,10 @@ import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import androidx.paging.map
+import com.egobook.app.analytics.AnalyticsEvent
+import com.egobook.app.analytics.AnalyticsLogger
+import com.egobook.app.analytics.AnalyticsParam
+import com.egobook.app.domain.model.square.letter.LetterMode
 import com.egobook.app.domain.usecase.GetFriendListUseCase
 import com.egobook.app.domain.usecase.GetUserInfoUseCase
 import com.egobook.app.store.data.ShopRepository
@@ -63,7 +67,8 @@ class LetterViewModel @Inject constructor(
     private val deleteLetterThreadUseCase: DeleteLetterThreadUseCase,
     private val getDeferredLettersUseCase: GetDeferredLettersUseCase,
     private val getUserInfoUseCase: GetUserInfoUseCase,
-    private val getReceivedReplyByIdUseCase: GetReceivedReplyByIdUseCase
+    private val getReceivedReplyByIdUseCase: GetReceivedReplyByIdUseCase,
+    private val analyticsLogger: AnalyticsLogger
 ): ViewModel() {
 
     private val _letterPaperItems = MutableStateFlow<UiState<List<LetterPaperItem>>>(UiState.Idle)
@@ -106,6 +111,10 @@ class LetterViewModel @Inject constructor(
         viewModelScope.launch {
             _sendLetterResult.emit(UiState.Loading)
             sendLetterUseCase(letter = letter.toDomain()).onSuccess {
+                analyticsLogger.logEvent(
+                    AnalyticsEvent.LETTER_SEND,
+                    mapOf(AnalyticsParam.TARGET_TYPE to letter.mode.value.lowercase())
+                )
                 _sendLetterResult.emit(UiState.Success(it))
             }.onFailure { error ->
                 _sendLetterResult.emit(UiState.Failure(error.message))
@@ -130,11 +139,28 @@ class LetterViewModel @Inject constructor(
     private val _arrivedPendingLetterResult = MutableStateFlow<UiState<ArrivedPendingLetterModel>>(UiState.Idle) // stateflow vs sharedflow
     val arrivedPendingLetterResult = _arrivedPendingLetterResult.asStateFlow()
 
+    // 화면 재진입마다 같은 편지를 다시 폴링해도 letter_receive가 중복 집계되지 않도록 마지막으로 집계한 편지 ID를 기억한다.
+    private var lastNotifiedArrivedLetterId: Long? = null
+
     fun getArrivedPendingLetter() {
         viewModelScope.launch {
             _arrivedPendingLetterResult.value = UiState.Loading
             getArrivedPendingLetterUseCase().onSuccess { domain ->
-                _arrivedPendingLetterResult.value = UiState.Success(domain.toPresentation())
+                val presentation = domain.toPresentation()
+                presentation.letter?.let { letter ->
+                    if (letter.letterId != lastNotifiedArrivedLetterId) {
+                        lastNotifiedArrivedLetterId = letter.letterId
+                        val fromType = when (letter.mode) {
+                            LetterMode.RANDOM -> "stranger"
+                            LetterMode.FRIEND -> "friend"
+                        }
+                        analyticsLogger.logEvent(
+                            AnalyticsEvent.LETTER_RECEIVE,
+                            mapOf(AnalyticsParam.FROM_TYPE to fromType)
+                        )
+                    }
+                }
+                _arrivedPendingLetterResult.value = UiState.Success(presentation)
             }.onFailure { error ->
                 _arrivedPendingLetterResult.value = UiState.Failure(error.message)
             }
@@ -152,6 +178,7 @@ class LetterViewModel @Inject constructor(
         viewModelScope.launch {
             _replyLetterResult.emit(UiState.Loading)
             replyLetterUseCase(letterId = letterId, text = text).onSuccess { domain ->
+                analyticsLogger.logEvent(AnalyticsEvent.LETTER_REPLY_SEND)
                 _replyLetterResult.emit(UiState.Success(domain.toPresentation()))
             }.onFailure { error ->
                 _replyLetterResult.emit(UiState.Failure(error.message))
@@ -180,6 +207,7 @@ class LetterViewModel @Inject constructor(
         viewModelScope.launch {
             _giveUpReplyLetterResult.emit(UiState.Loading)
             giveUpReplyLetterUseCase(letterId = letterId).onSuccess {
+                analyticsLogger.logEvent(AnalyticsEvent.LETTER_GIVE_UP)
                 _giveUpReplyLetterResult.emit(UiState.Success(Unit))
             }.onFailure { error ->
                 _giveUpReplyLetterResult.emit(UiState.Failure(error.message))
@@ -219,6 +247,10 @@ class LetterViewModel @Inject constructor(
         viewModelScope.launch {
             _reportArrivedLetterResult.emit(UiState.Loading)
             reportArrivedLetterUseCase(letterId = letterId, reportContent = reportLetter.toDomain()).onSuccess {
+                analyticsLogger.logEvent(
+                    AnalyticsEvent.LETTER_REPORT,
+                    mapOf(AnalyticsParam.REASON to reportLetter.reason.value.lowercase())
+                )
                 _reportArrivedLetterResult.emit(UiState.Success(it))
             }.onFailure { error ->
                 _reportArrivedLetterResult.emit(UiState.Failure(error.message))
@@ -233,6 +265,10 @@ class LetterViewModel @Inject constructor(
         viewModelScope.launch {
             _reportRepliedLetterResult.emit(UiState.Loading)
             reportRepliedLetterUseCase(replyId = replyId, reportContent = reportLetter.toDomain()).onSuccess {
+                analyticsLogger.logEvent(
+                    AnalyticsEvent.LETTER_REPORT,
+                    mapOf(AnalyticsParam.REASON to reportLetter.reason.value.lowercase())
+                )
                 _reportRepliedLetterResult.emit(UiState.Success(it))
             }.onFailure { error ->
                 _reportRepliedLetterResult.emit(UiState.Failure(error.message))
@@ -247,6 +283,7 @@ class LetterViewModel @Inject constructor(
         viewModelScope.launch {
             _deleteLetterThreadResult.emit(UiState.Loading)
             deleteLetterThreadUseCase(threadId = threadId).onSuccess {
+                analyticsLogger.logEvent(AnalyticsEvent.LETTER_DELETE)
                 _deleteLetterThreadResult.emit(UiState.Success(it))
             }.onFailure { error ->
                 _deleteLetterThreadResult.emit(UiState.Failure(error.message))

--- a/app/src/main/java/com/egobook/app/ui/square/viewmodel/QuestionViewModel.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/viewmodel/QuestionViewModel.kt
@@ -5,6 +5,9 @@ import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import androidx.paging.map
+import com.egobook.app.analytics.AnalyticsEvent
+import com.egobook.app.analytics.AnalyticsLogger
+import com.egobook.app.analytics.AnalyticsParam
 import com.egobook.app.domain.usecase.DeleteMyQuestionAnswerUseCase
 import com.egobook.app.domain.usecase.GetMyRepliesHistoryUseCase
 import com.egobook.app.domain.usecase.GetTodayAllUserRepliesUseCase
@@ -42,7 +45,8 @@ class QuestionViewModel @Inject constructor(
     private val updateTodayAnswerUseCase: UpdateTodayAnswerUseCase,
     private val deleteMyQuestionAnswerUseCase: DeleteMyQuestionAnswerUseCase,
     private val reportTodayQuestionAnswerUseCase: ReportTodayQuestionAnswerUseCase,
-    private val updateMarketingConsentUseCase: UpdateMarketingConsentUseCase
+    private val updateMarketingConsentUseCase: UpdateMarketingConsentUseCase,
+    private val analyticsLogger: AnalyticsLogger
 ): ViewModel() {
 
     private val _todayQuestion = MutableStateFlow<UiState<TodayQuestionModel>>(UiState.Idle)
@@ -66,6 +70,10 @@ class QuestionViewModel @Inject constructor(
         viewModelScope.launch {
             _submitTodayAnswerResult.emit(UiState.Loading)
             submitTodayAnswerUseCase(answer = answer.toDomain()).onSuccess {
+                analyticsLogger.logEvent(
+                    AnalyticsEvent.QUESTION_ANSWER_WRITE,
+                    mapOf(AnalyticsParam.VISIBILITY to answer.visibilityType.value.lowercase())
+                )
                 _submitTodayAnswerResult.emit(UiState.Success(it))
             }.onFailure { error ->
                 _submitTodayAnswerResult.emit(UiState.Failure(error.message))
@@ -100,6 +108,7 @@ class QuestionViewModel @Inject constructor(
 
     fun getTodayAllUserReplies(size: Int) {
         viewModelScope.launch {
+            analyticsLogger.logEvent(AnalyticsEvent.QUESTION_VIEW_ALL)
             getTodayAllUserRepliesUseCase(size = size).cachedIn(viewModelScope).collectLatest { pagingData ->
                 _todayAllUserReplies.value = pagingData.map { it.toPresentation() }
             }
@@ -113,6 +122,7 @@ class QuestionViewModel @Inject constructor(
         viewModelScope.launch {
             _updateTodayAnswerResult.emit(UiState.Loading)
             updateTodayAnswerUseCase(updatedAnswer = updatedAnswer.toDomain()).onSuccess {
+                analyticsLogger.logEvent(AnalyticsEvent.QUESTION_ANSWER_EDIT)
                 _updateTodayAnswerResult.emit(UiState.Success(it))
             }.onFailure { error ->
                 _updateTodayAnswerResult.emit(UiState.Failure(error.message))
@@ -127,6 +137,7 @@ class QuestionViewModel @Inject constructor(
         viewModelScope.launch {
             _deleteMyQuestionAnswerResult.emit(UiState.Loading)
             deleteMyQuestionAnswerUseCase(answerId = answerId).onSuccess {
+                analyticsLogger.logEvent(AnalyticsEvent.QUESTION_ANSWER_DELETE)
                 _deleteMyQuestionAnswerResult.emit(UiState.Success(it))
             }.onFailure { error ->
                 _deleteMyQuestionAnswerResult.emit(UiState.Failure(error.message))
@@ -141,6 +152,10 @@ class QuestionViewModel @Inject constructor(
         viewModelScope.launch {
             _reportTodayQuestionAnswerResult.emit(UiState.Loading)
             reportTodayQuestionAnswerUseCase(answerId = answerId, request = request.toDomain()).onSuccess {
+                analyticsLogger.logEvent(
+                    AnalyticsEvent.QUESTION_ANSWER_REPORT,
+                    mapOf(AnalyticsParam.REASON to request.reason.value.lowercase())
+                )
                 _reportTodayQuestionAnswerResult.emit(UiState.Success(it))
             }.onFailure { error ->
                 _reportTodayQuestionAnswerResult.emit(UiState.Failure(error.message))

--- a/app/src/test/java/com/egobook/app/store/ui/StoreViewModelTest.kt
+++ b/app/src/test/java/com/egobook/app/store/ui/StoreViewModelTest.kt
@@ -2,6 +2,7 @@ package com.egobook.app.store.ui
 
 import android.util.Log
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.egobook.app.analytics.AnalyticsLogger
 import com.egobook.app.store.data.ShopRepository
 import com.egobook.app.store.data.model.ItemStatus
 import com.egobook.app.store.data.model.ItemType
@@ -36,6 +37,7 @@ class StoreViewModelTest {
 
     private lateinit var shopRepository: ShopRepository
     private lateinit var userRepository: UserRepository
+    private lateinit var analyticsLogger: AnalyticsLogger
     private lateinit var viewModel: StoreViewModel
     private val testDispatcher = StandardTestDispatcher()
 
@@ -47,8 +49,13 @@ class StoreViewModelTest {
         every { Log.d(any(), any()) } returns 0
         shopRepository = mockk()
         userRepository = mockk()
+        analyticsLogger = mockk(relaxed = true)
         every { shopRepository.itemStream } returns flowOf(emptyList())
-        viewModel = StoreViewModel(shopRepository = shopRepository, userRepository = userRepository)
+        viewModel = StoreViewModel(
+            shopRepository = shopRepository,
+            userRepository = userRepository,
+            analyticsLogger = analyticsLogger
+        )
     }
 
     @After

--- a/app/src/test/java/com/egobook/app/ui/diary/viewmodel/DiariesViewModelTest.kt
+++ b/app/src/test/java/com/egobook/app/ui/diary/viewmodel/DiariesViewModelTest.kt
@@ -2,6 +2,7 @@ package com.egobook.app.ui.diary.viewmodel
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.paging.PagingData
+import com.egobook.app.analytics.AnalyticsLogger
 import com.egobook.app.domain.model.diary.entity.DiarySummary
 import com.egobook.app.domain.usecase.diaryusecase.DiaryUseCases
 import com.egobook.app.domain.usecase.diaryusecase.GetDailyCount
@@ -35,6 +36,7 @@ class DiariesViewModelTest {
     private lateinit var diaryUseCases: DiaryUseCases
     private lateinit var getDailyCount: GetDailyCount
     private lateinit var getDiaries: GetDiaries
+    private lateinit var analyticsLogger: AnalyticsLogger
     private val testDispatcher = StandardTestDispatcher()
 
     @Before
@@ -58,7 +60,8 @@ class DiariesViewModelTest {
             exportDiary = mockk(),
         )
 
-        viewModel = DiariesViewModel(diaryUseCases)
+        analyticsLogger = mockk(relaxed = true)
+        viewModel = DiariesViewModel(diaryUseCases, analyticsLogger)
     }
 
     @After

--- a/app/src/test/java/com/egobook/app/ui/square/viewmodel/QuestionViewModelTest.kt
+++ b/app/src/test/java/com/egobook/app/ui/square/viewmodel/QuestionViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.egobook.app.ui.square.viewmodel
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.egobook.app.analytics.AnalyticsLogger
 import com.egobook.app.domain.usecase.UpdateMarketingConsentUseCase
 import com.egobook.app.util.UiState
 import io.mockk.coEvery
@@ -30,6 +31,7 @@ class QuestionViewModelTest {
 
     private lateinit var viewModel: QuestionViewModel
     private lateinit var updateMarketingConsentUseCase: UpdateMarketingConsentUseCase
+    private lateinit var analyticsLogger: AnalyticsLogger
     private val testDispatcher = StandardTestDispatcher()
 
     @Before
@@ -37,6 +39,7 @@ class QuestionViewModelTest {
         Dispatchers.setMain(testDispatcher)
 
         updateMarketingConsentUseCase = mockk()
+        analyticsLogger = mockk(relaxed = true)
 
         viewModel = QuestionViewModel(
             getTodayQuestionUseCase = mockk(),
@@ -47,7 +50,8 @@ class QuestionViewModelTest {
             updateTodayAnswerUseCase = mockk(),
             deleteMyQuestionAnswerUseCase = mockk(),
             reportTodayQuestionAnswerUseCase = mockk(),
-            updateMarketingConsentUseCase = updateMarketingConsentUseCase
+            updateMarketingConsentUseCase = updateMarketingConsentUseCase,
+            analyticsLogger = analyticsLogger
         )
     }
 


### PR DESCRIPTION
## 📝 작업 내용
- Firebase Analytics 도입: FirebaseAnalytics를 Hilt로 주입하는 AnalyticsModule과, 로깅 실패가 앱 로직에 영향을 주지 않도록 try-catch로 격리한 공용 AnalyticsLogger 추가
- 로그인/가입, 계정/상점/알림, 메인페이지, 감정일기, 에고룸, 광장/친구 전 영역에 걸쳐 총 45개 커스텀 이벤트 계측 (ViewModel 16개 + OnboardingActivity)
  - 표준 이벤트: `login`, `sign_up`
  - 커스텀 이벤트: `onboarding_complete`, `shop_open/exit`, `item_purchase`, `item_equip`, `diary_write/edit/delete/export`, `weekly_report_unlock` 등
- 코드 리뷰 과정에서 발견한 계측 정확도 이슈 수정
  - `ad_reward_watch`가 시청 전 캐시값을 써서 부정확했던 것 → 시청 직후 서버에서 최신 값을 다시 조회하도록 수정
  - `letter_receive`가 같은 대기 편지를 화면 재진입할 때마다 중복 집계하던 것 → 마지막 편지 ID 기억해서 중복 방지
  - `shop_open`이 화면 회전 시 중복 집계되던 것 → `savedInstanceState == null`일 때만 기록
- 기존 기능 로직(리턴값·흐름·타이밍)은 건드리지 않고 성공 콜백 안에 로깅 코드만 순수 추가
- develop 브랜치 병합(#116, 홈 벨 아이콘 레드닷) 반영 — `HomeFragment.kt`에서 겹쳤으나 서로 다른 영역이라 충돌 없이 자동 병합됨

## 🔗 관련 이슈
- Close #114

## 📸 스크린샷
- UI 변경은 없습니다 (분석 이벤트 계측만 추가). 

## 💬 요구사항(선택)
- 전체적으로 많이 건들였습니다. 혹시라도 잘못 만진 곳이 있다면 알려주세요.

## ✅ 체크리스트
- [x] 관련 없는 변경사항 삭제 했는가? (불필요한 주석, 로그 등)
- [x] 테스트 여부 (Unit Test 등) — 생성자 변경으로 영향받은 기존 테스트 3건 보강, 전체 유닛 테스트/빌드 통과 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 온보딩 완료, 로그인·계정 관리, 상점, 알림, 일기, 통계, 심리 지식, 친구·광장 활동 등 주요 사용자 행동을 Firebase Analytics로 기록합니다.
  - 상점 방문·이탈, 아이템 구매·장착 및 일기 작성·수정·삭제·내보내기 활동을 추적합니다.
  - 친구 요청, 편지·질문 답변, 신고 등 커뮤니티 활동도 분석 대상에 포함됩니다.

- **개선 사항**
  - 동일 화면 복원이나 중복 조회로 인한 분석 이벤트 중복 기록을 방지합니다.
  - 분석 기록 중 오류가 발생해도 앱의 기존 기능 흐름은 중단되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->