### PR TITLE
✨Feat - 로딩바 디자인 통일

### DIFF
--- a/app/src/main/java/com/egobook/app/ui/diary/view/DiaryCheckFragment.kt
+++ b/app/src/main/java/com/egobook/app/ui/diary/view/DiaryCheckFragment.kt
@@ -102,19 +102,19 @@ class DiaryCheckFragment : Fragment() {
                 viewModel.diaryState.collectLatest { state ->
                     when (state) {
                         is UiState.Idle -> {
-                            binding.progressBar.visibility = View.GONE
+                            binding.pbLoading.visibility = View.GONE
                             binding.ivEmotion.visibility = View.GONE
                         }
                         is UiState.Loading -> {
-                            binding.progressBar.visibility = View.VISIBLE
+                            binding.pbLoading.visibility = View.VISIBLE
                             binding.ivEmotion.visibility = View.GONE
                         }
                         is UiState.Success -> {
-                            binding.progressBar.visibility = View.GONE
+                            binding.pbLoading.visibility = View.GONE
                             updateUi(state.data)
                         }
                         is UiState.Failure -> {
-                            binding.progressBar.visibility = View.GONE
+                            binding.pbLoading.visibility = View.GONE
                             binding.ivEmotion.visibility = View.GONE
                             val message = state.message ?: "알 수 없는 오류가 발생했습니다."
                             Toast.makeText(requireContext(), 

--- a/app/src/main/java/com/egobook/app/ui/diary/view/DiaryListFragment.kt
+++ b/app/src/main/java/com/egobook/app/ui/diary/view/DiaryListFragment.kt
@@ -92,18 +92,18 @@ class DiaryListFragment : Fragment() {
                 when (val refreshState = loadStates.refresh) {
                     is LoadState.Loading -> {
                         // 초기 로딩 중
-                        binding.progressBar.isVisible = true
+                        binding.pbLoading.isVisible = true
                         binding.rvDiary.isVisible = false
                         binding.layoutEmpty.isVisible = false
                     }
                     is LoadState.NotLoading -> {
-                        binding.progressBar.isVisible = false
+                        binding.pbLoading.isVisible = false
                         val isEmpty = diaryRVAdapter.itemCount == 0
                         binding.layoutEmpty.isVisible = isEmpty
                         binding.rvDiary.isVisible = !isEmpty
                     }
                     is LoadState.Error -> {
-                        binding.progressBar.isVisible = false
+                        binding.pbLoading.isVisible = false
                         // TODO: 에러 UI 처리
                     }
                 }

--- a/app/src/main/java/com/egobook/app/ui/diary/view/DiaryWriteFragment.kt
+++ b/app/src/main/java/com/egobook/app/ui/diary/view/DiaryWriteFragment.kt
@@ -221,7 +221,7 @@ class DiaryWriteFragment : Fragment() {
                 viewModel.contentState.collectLatest { state ->
                     when (val loadState = state.diaryLoadState) {
                         is UiState.Loading -> {
-                            binding.progressBar.isVisible = true
+                            binding.pbLoading.isVisible = true
                             // 입력 UI 숨기기
                             binding.guideLayout.isVisible = false
                             binding.typeLayout.isVisible = false
@@ -232,7 +232,7 @@ class DiaryWriteFragment : Fragment() {
                             binding.btnSave.isVisible = false
                         }
                         is UiState.Success, is UiState.Idle -> {
-                            binding.progressBar.isVisible = false
+                            binding.pbLoading.isVisible = false
                             // 입력 UI 표시
                             binding.guideLayout.isVisible = true
                             binding.typeLayout.isVisible = true
@@ -241,7 +241,7 @@ class DiaryWriteFragment : Fragment() {
                             binding.btnSave.isVisible = true
                         }
                         is UiState.Failure -> {
-                            binding.progressBar.isVisible = false
+                            binding.pbLoading.isVisible = false
                             // 에러 처리 (필요시 토스트 또는 에러 UI 표시)
                             Toast.makeText(requireContext(), loadState.message ?: "데이터 로드에 실패했습니다.", Toast.LENGTH_SHORT).show()
                         }
@@ -301,7 +301,7 @@ class DiaryWriteFragment : Fragment() {
                     when (result) {
                         is DiaryWriteViewModel.SaveResult.Loading -> {
                             // 저장 중
-                            binding.progressBar.visibility = View.VISIBLE
+                            binding.pbLoading.visibility = View.VISIBLE
                             binding.btnSave.isEnabled = false
                         }
                         is DiaryWriteViewModel.SaveResult.Success -> {

--- a/app/src/main/java/com/egobook/app/ui/home/ui/AdDialog.kt
+++ b/app/src/main/java/com/egobook/app/ui/home/ui/AdDialog.kt
@@ -56,10 +56,10 @@ class AdDialog() : DialogFragment() {
                 launch {
                     viewModel.isLoadingAdInfo.collect { isLoading ->
                         if (isLoading) {
-                            binding.progressBar.visibility = View.VISIBLE
+                            binding.pbLoading.visibility = View.VISIBLE
                             binding.contentLayout.visibility = View.GONE
                         } else {
-                            binding.progressBar.visibility = View.GONE
+                            binding.pbLoading.visibility = View.GONE
                             binding.contentLayout.visibility = View.VISIBLE
                         }
                     }

--- a/app/src/main/java/com/egobook/app/ui/home/ui/RadarDialog.kt
+++ b/app/src/main/java/com/egobook/app/ui/home/ui/RadarDialog.kt
@@ -57,7 +57,7 @@ class RadarDialog : DialogFragment() {
                 launch {
                     viewModel.tendencies.collect { data ->
                         if (data.isNotEmpty()) {
-                            binding.progressBar.visibility = View.GONE
+                            binding.pbLoading.visibility = View.GONE
                             binding.contentLayout.visibility = View.VISIBLE
                             radarView.setRadarData(data.sortedBy { it.type.order() }.map { it.experiencePoint })
                             showTendencyLevel(data)
@@ -67,7 +67,7 @@ class RadarDialog : DialogFragment() {
                 launch {
                     viewModel.isLoading.collect { isLoading ->
                         if (isLoading && viewModel.tendencies.value.isEmpty()) {
-                            binding.progressBar.visibility = View.VISIBLE
+                            binding.pbLoading.visibility = View.VISIBLE
                             binding.contentLayout.visibility = View.GONE
                         }
                     }

--- a/app/src/main/java/com/egobook/app/ui/login/view/LoginActivity.kt
+++ b/app/src/main/java/com/egobook/app/ui/login/view/LoginActivity.kt
@@ -190,13 +190,13 @@ import javax.inject.Inject
             viewModel.loginState.collect { state ->
                 when (state) {
                     is LoginState.Loading -> {
-                        binding.progressBar.visibility = View.VISIBLE
+                        binding.pbLoading.visibility = View.VISIBLE
                         binding.btnLogin.isEnabled = false
                         binding.btnGoogleLogin.isEnabled = false
                         binding.btnGuestLogin.isEnabled = false
                     }
                     is LoginState.Success -> {
-                        binding.progressBar.visibility = View.GONE
+                        binding.pbLoading.visibility = View.GONE
                         Toast.makeText(
                             this@LoginActivity,
                             "로그인 성공!",
@@ -205,7 +205,7 @@ import javax.inject.Inject
                         navigateToMain()
                     }
 //                    is LoginState.Error -> {
-//                        binding.progressBar.visibility = View.GONE
+//                        binding.pbLoading.visibility = View.GONE
 //                        val message = state.error.message ?: "알 수 없는 오류가 발생했습니다"
 //                        Toast.makeText(
 //                            this@LoginActivity,
@@ -214,10 +214,10 @@ import javax.inject.Inject
 //                        ).show()
 //                    }
 //                    else -> {
-//                        binding.progressBar.visibility = View.GONE
+//                        binding.pbLoading.visibility = View.GONE
 //                    }
                     is LoginState.Error -> {
-                        binding.progressBar.visibility = View.GONE
+                        binding.pbLoading.visibility = View.GONE
                         binding.btnLogin.isEnabled = true
                         binding.btnGoogleLogin.isEnabled = true
                         binding.btnGuestLogin.isEnabled = true
@@ -242,7 +242,7 @@ import javax.inject.Inject
 //                        }
                     }
                     else -> {
-                        binding.progressBar.visibility = View.GONE
+                        binding.pbLoading.visibility = View.GONE
                         binding.btnLogin.isEnabled = true
                         binding.btnGoogleLogin.isEnabled = true
                         binding.btnGuestLogin.isEnabled = true

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -20,10 +20,10 @@
             android:background="@drawable/img_login_background_ver2">
 
             <ProgressBar
-                android:id="@+id/progress_bar"
-                android:layout_width="48dp"
-                android:layout_height="48dp"
-                android:indeterminateTint="@color/cos_black"
+                android:id="@+id/pb_loading"
+                style="@style/LoadingProgressBarStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
                 android:visibility="gone"
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -60,11 +60,10 @@
         </eightbitlab.com.blurview.BlurView>
 
         <ProgressBar
-            android:id="@+id/loading_progress"
+            android:id="@+id/pb_loading"
             style="@style/LoadingProgressBarStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:indeterminate="true"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/dialog_ad.xml
+++ b/app/src/main/res/layout/dialog_ad.xml
@@ -19,7 +19,7 @@
         android:orientation="vertical" >
 
         <ProgressBar
-            android:id="@+id/progress_bar"
+            android:id="@+id/pb_loading"
             style="@style/LoadingProgressBarStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -128,12 +128,5 @@
         </LinearLayout>
 
     </LinearLayout>
-
-    <ProgressBar
-        android:id="@+id/pb_loading"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:visibility="gone" />
 
 </FrameLayout>

--- a/app/src/main/res/layout/dialog_radar.xml
+++ b/app/src/main/res/layout/dialog_radar.xml
@@ -14,7 +14,7 @@
         android:paddingVertical="24dp">
 
         <ProgressBar
-            android:id="@+id/progress_bar"
+            android:id="@+id/pb_loading"
             style="@style/LoadingProgressBarStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_diary_check.xml
+++ b/app/src/main/res/layout/fragment_diary_check.xml
@@ -234,10 +234,10 @@
         android:layout_marginBottom="16dp"/>
 
     <ProgressBar
-        android:id="@+id/progress_bar"
-        android:layout_width="48dp"
-        android:layout_height="48dp"
-        android:indeterminateTint="@color/cos_black"
+        android:id="@+id/pb_loading"
+        style="@style/LoadingProgressBarStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:visibility="gone"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/fragment_diary_list.xml
+++ b/app/src/main/res/layout/fragment_diary_list.xml
@@ -46,10 +46,10 @@
     </LinearLayout>
     
     <ProgressBar
-        android:id="@+id/progress_bar"
-        android:layout_width="48dp"
-        android:layout_height="48dp"
-        android:indeterminateTint="@color/cos_black"
+        android:id="@+id/pb_loading"
+        style="@style/LoadingProgressBarStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:visibility="gone"
         tools:visibility="visible"
         android:layout_gravity="center"/>

--- a/app/src/main/res/layout/fragment_diary_write.xml
+++ b/app/src/main/res/layout/fragment_diary_write.xml
@@ -392,10 +392,10 @@
             android:layout_marginEnd="16dp" />
 
         <ProgressBar
-            android:id="@+id/progress_bar"
-            android:layout_width="48dp"
-            android:layout_height="48dp"
-            android:indeterminateTint="@color/cos_black"
+            android:id="@+id/pb_loading"
+            style="@style/LoadingProgressBarStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             android:visibility="gone"
             tools:visibility="visible"
             app:layout_constraintTop_toTopOf="parent"

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -256,6 +256,7 @@
 
         <ProgressBar
             android:id="@+id/pb_loading"
+            style="@style/LoadingProgressBarStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center" />

--- a/app/src/main/res/layout/fragment_store.xml
+++ b/app/src/main/res/layout/fragment_store.xml
@@ -208,6 +208,7 @@
 
     <ProgressBar
         android:id="@+id/pb_loading"
+        style="@style/LoadingProgressBarStyle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:visibility="gone"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -196,9 +196,10 @@
         <item name="android:textColor">@color/cos_black</item>
     </style>
 
-    <!-- 로딩 ProgressBar 스타일 -->
+    <!-- 로딩 ProgressBar 공통 스타일 (앱 전체 로딩 인디케이터는 이 스타일만 사용) -->
     <style name="LoadingProgressBarStyle" parent="Widget.AppCompat.ProgressBar">
-        <item name="android:indeterminateTint">@color/emotion_very_happy</item>
+        <item name="android:indeterminate">true</item>
+        <item name="android:indeterminateTint">@color/cos_black</item>
         <item name="android:indeterminateTintMode">src_atop</item>
         <item name="android:minWidth">48dp</item>
         <item name="android:minHeight">48dp</item>


### PR DESCRIPTION
## 📝 작업 내용

앱 전반의 로딩 인디케이터가 화면마다 스타일 적용 여부·색상·크기·id가 제각각이어서 하나의 공통 스타일로 통일했습니다.

### 공통 스타일 정리 (`styles.xml`)
- `indeterminateTint`를 `@color/cos_black`으로 통일
- `android:indeterminate="true"`를 스타일에 포함시켜 레이아웃별 중복 지정 제거

### ProgressBar 11개 전부 공통 스타일로 통일
- 스타일 미적용이던 7개 레이아웃에 `@style/LoadingProgressBarStyle` 적용
  - `activity_login`, `fragment_diary_check`, `fragment_diary_write`, `fragment_diary_list`, `fragment_home`, `fragment_store`, `dialog_ad`
- 인라인 `android:indeterminateTint`와 하드코딩된 `48dp` 제거 → `wrap_content` + 스타일의 `minWidth`/`minHeight`로 통일

### id 네이밍 통일
- `progress_bar`, `loading_progress` → **`pb_loading`** 으로 통일
- 이에 따라 Kotlin 바인딩 참조 27곳 갱신
  - `LoginActivity`, `DiaryCheckFragment`, `DiaryWriteFragment`, `DiaryListFragment`, `AdDialog`, `RadarDialog`

### 기타
- `dialog_ad.xml`에 코드에서 참조되지 않는 중복 ProgressBar가 있었고, id 통일 시 충돌하므로 제거했습니다

## 🔗 관련 이슈
- Close #121

## 📸 스크린샷
- 로딩 인디케이터 색상이 화면별로 `emotion_very_happy`(#E69090) / `cos_black`(#191818) / 시스템 기본색으로 나뉘어 있던 것을 `cos_black`으로 통일했습니다.
- 색상 변경이 실제로 보이는 화면: 홈, 심리검사, 스토어, 광고 다이얼로그, 레이더 다이얼로그, 메인

## 💬 요구사항(선택)
- **로딩 색상을 `cos_black`으로 결정한 부분에 디자이너 컨펌이 필요합니다.** 기존에 `LoadingProgressBarStyle`이 쓰던 `emotion_very_happy`(#E69090)와 인라인으로 쓰이던 `cos_black` 중 후자로 통일했습니다.
- `dialog_detect_abusive_content_loading`(고북이 이미지 기반 로딩)은 ProgressBar가 아닌 별도 구현이라 이번 범위에서 제외했습니다. 전체 로딩 정책을 어떻게 가져갈지는 별도 논의가 필요해 보입니다.
- id 변경 범위가 넓어 **로딩이 실제로 노출되는 화면(로그인 / 홈 / 다이어리 목록·작성·확인 / 스토어 / 심리검사 / 광고·레이더 다이얼로그) 동작 확인**을 부탁드립니다.

## ✅ 체크리스트
- [x] 관련 없는 변경사항 삭제 했는가? (불필요한 주석, 로그 등)
- [x] 빌드 검증 (`./gradlew :app:assembleDebug` BUILD SUCCESSFUL)
- [ ] 실기기 QA (위 요구사항 항목 참고)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 일기 확인, 목록, 작성 및 로그인 화면의 로딩 표시가 공통 스타일로 통일되었습니다.
  - 광고 및 레이더 정보 로딩 화면에도 일관된 로딩 인디케이터가 적용되었습니다.
  - 로딩 인디케이터의 크기와 색상이 화면 전반에서 일관되게 표시됩니다.
  - 광고 대화상자의 중복 로딩 표시가 제거되어 화면이 간결해졌습니다.
  - 각 화면에서 데이터 로딩 및 저장 상태에 따른 표시·숨김 동작은 기존과 동일하게 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->