### PR TITLE
✨Feat - FCM 푸시 알림 연동

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -180,6 +180,7 @@ dependencies {
     implementation("com.google.android.gms:play-services-ads:23.6.0")
     implementation(platform("com.google.firebase:firebase-bom:34.12.0"))
     implementation("com.google.firebase:firebase-analytics")
+    implementation("com.google.firebase:firebase-messaging")
 
     implementation(libs.androidx.room.runtime)
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:name=".MyApplication"
@@ -20,6 +21,25 @@
         <meta-data
             android:name="com.google.android.gms.ads.APPLICATION_ID"
             android:value="${ADMOB_APP_ID}" />
+
+        <!-- FCM 알림 기본 설정 -->
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_icon"
+            android:resource="@drawable/ic_notification" />
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_color"
+            android:resource="@color/brand" />
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_channel_id"
+            android:value="@string/default_notification_channel_id" />
+
+        <service
+            android:name=".push.EgobookMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
         <activity
             android:name=".ui.login.view.IntroActivity"
             android:exported="true"

--- a/app/src/main/java/com/egobook/app/MyApplication.kt
+++ b/app/src/main/java/com/egobook/app/MyApplication.kt
@@ -1,6 +1,7 @@
 package com.egobook.app
 
 import android.app.Application
+import com.egobook.app.push.NotificationChannels
 import dagger.hilt.android.HiltAndroidApp
 import timber.log.Timber
 
@@ -13,6 +14,8 @@ class MyApplication : Application() {
         if (BuildConfig.DEBUG) {
             Timber.plant(AppDebugTree())
         }
+
+        NotificationChannels.createAll(this)
     }
 
     private class AppDebugTree : Timber.DebugTree() {

--- a/app/src/main/java/com/egobook/app/data/api/PushApiService.kt
+++ b/app/src/main/java/com/egobook/app/data/api/PushApiService.kt
@@ -1,0 +1,15 @@
+package com.egobook.app.data.api
+
+import com.egobook.app.data.model.ApiResponse
+import com.egobook.app.data.model.push.FcmTokenRequest
+import com.google.gson.JsonElement
+import retrofit2.http.Body
+import retrofit2.http.PATCH
+
+interface PushApiService {
+    // data 필드가 문자열/객체/null 어느 것이든 Gson이 파싱 가능하도록 JsonElement? 사용
+    @PATCH("/users/fcm-token")
+    suspend fun updateFcmToken(
+        @Body request: FcmTokenRequest,
+    ): ApiResponse<JsonElement?>
+}

--- a/app/src/main/java/com/egobook/app/data/interceptor/TokenAuthenticator.kt
+++ b/app/src/main/java/com/egobook/app/data/interceptor/TokenAuthenticator.kt
@@ -3,6 +3,7 @@ package com.egobook.app.data.interceptor
 import android.content.Context
 import android.content.Intent
 import com.egobook.app.data.api.AuthApiService
+import com.egobook.app.data.local.PushPreferenceStorage
 import com.egobook.app.data.local.UserInfoStorage
 import com.egobook.app.data.model.auth.AccessTokenRequest
 import com.egobook.app.di.qualifier.AuthRetrofit
@@ -20,6 +21,7 @@ import javax.inject.Inject
 class TokenAuthenticator @Inject constructor(
     @param:ApplicationContext private val context: Context,
     private val userInfoStorage: UserInfoStorage,
+    private val pushPreferenceStorage: PushPreferenceStorage,
     private val authApiService: AuthApiService
 ) : Authenticator {
 
@@ -102,6 +104,8 @@ class TokenAuthenticator @Inject constructor(
 
         runBlocking {
             userInfoStorage.clearAll()   // 토큰, id, 이메일 등등 싹다 삭제
+            // 다른 계정으로 재로그인했을 때 같은 토큰이라는 이유로 등록이 생략되지 않도록 이력 삭제
+            pushPreferenceStorage.clearLastRegisteredToken()
         }
 
         val intent = Intent(context, LoginActivity::class.java).apply {

--- a/app/src/main/java/com/egobook/app/data/local/PushPreferenceStorage.kt
+++ b/app/src/main/java/com/egobook/app/data/local/PushPreferenceStorage.kt
@@ -1,0 +1,71 @@
+package com.egobook.app.data.local
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private val Context.pushDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "egobook_notification",
+)
+
+/**
+ * 푸시 알림 관련 로컬 상태를 저장하는 저장소.
+ *
+ * 알림 권한 요청 이력과 마지막으로 서버 등록에 성공한 FCM 토큰을 보관한다.
+ * 로그아웃 시 초기화되면 안 되므로 인증 정보를 담는 [UserInfoStorage]와 파일을 분리한다.
+ */
+@Singleton
+class PushPreferenceStorage
+    @Inject
+    constructor(
+        private val context: Context,
+    ) {
+        private val dataStore = context.pushDataStore
+
+        suspend fun hasRequestedPermissionBefore(): Boolean =
+            dataStore.data
+                .map { preferences -> preferences[KEY_HAS_REQUESTED_PERMISSION] ?: false }
+                .first()
+
+        suspend fun markPermissionRequested() {
+            dataStore.edit { preferences ->
+                preferences[KEY_HAS_REQUESTED_PERMISSION] = true
+            }
+        }
+
+        suspend fun getLastRegisteredToken(): String? =
+            dataStore.data
+                .map { preferences -> preferences[KEY_LAST_REGISTERED_TOKEN] }
+                .first()
+
+        suspend fun saveLastRegisteredToken(token: String) {
+            dataStore.edit { preferences ->
+                preferences[KEY_LAST_REGISTERED_TOKEN] = token
+            }
+        }
+
+        /**
+         * 로그아웃 시 호출한다.
+         * 다른 계정으로 로그인했을 때 같은 토큰이라는 이유로 등록이 생략되지 않도록 이력을 지운다.
+         */
+        suspend fun clearLastRegisteredToken() {
+            dataStore.edit { preferences ->
+                preferences.remove(KEY_LAST_REGISTERED_TOKEN)
+            }
+        }
+
+        companion object {
+            private val KEY_HAS_REQUESTED_PERMISSION =
+                booleanPreferencesKey("has_requested_post_notifications")
+            private val KEY_LAST_REGISTERED_TOKEN =
+                stringPreferencesKey("last_registered_fcm_token")
+        }
+    }

--- a/app/src/main/java/com/egobook/app/data/model/push/FcmTokenRequest.kt
+++ b/app/src/main/java/com/egobook/app/data/model/push/FcmTokenRequest.kt
@@ -1,0 +1,10 @@
+package com.egobook.app.data.model.push
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FcmTokenRequest(
+    @SerialName("fcmToken")
+    val fcmToken: String,
+)

--- a/app/src/main/java/com/egobook/app/data/repository/account/AccountRepositoryImpl.kt
+++ b/app/src/main/java/com/egobook/app/data/repository/account/AccountRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.egobook.app.data.repository.account
 
 import com.egobook.app.data.api.AccountApiService
+import com.egobook.app.data.local.PushPreferenceStorage
 import com.egobook.app.data.local.UserInfoStorage
 import com.egobook.app.data.model.account.LinkRequest
 import com.egobook.app.data.model.account.NicknameRequest
@@ -14,7 +15,8 @@ import timber.log.Timber
 
 class AccountRepositoryImpl @Inject constructor(
     private val apiService: AccountApiService,
-    private val userInfoStorage: UserInfoStorage
+    private val userInfoStorage: UserInfoStorage,
+    private val pushPreferenceStorage: PushPreferenceStorage
 ) : AccountRepository {
 
     override suspend fun getUserId(forceRefresh: Boolean): Result<String> {
@@ -97,6 +99,7 @@ class AccountRepositoryImpl @Inject constructor(
                 try {
                     //datastore의 모든 데이터 삭제
                     userInfoStorage.clearAll()
+                    pushPreferenceStorage.clearLastRegisteredToken()
                     Timber.d("회원 탈퇴 성공: UserInfoStorage 초기화 완료")
                 } catch (e: Exception) {
                     Timber.e(e, "회원 탈퇴 후 UserInfoStorage 초기화 실패")

--- a/app/src/main/java/com/egobook/app/data/repository/push/PushTokenRepositoryImpl.kt
+++ b/app/src/main/java/com/egobook/app/data/repository/push/PushTokenRepositoryImpl.kt
@@ -1,0 +1,59 @@
+package com.egobook.app.data.repository.push
+
+import com.egobook.app.BuildConfig
+import com.egobook.app.data.api.PushApiService
+import com.egobook.app.data.local.PushPreferenceStorage
+import com.egobook.app.data.model.push.FcmTokenRequest
+import com.egobook.app.data.util.safeApiCall
+import com.egobook.app.domain.repository.push.PushTokenRepository
+import com.egobook.app.push.PushTokenRegistrationPolicy
+import com.google.firebase.messaging.FirebaseMessaging
+import kotlinx.coroutines.suspendCancellableCoroutine
+import timber.log.Timber
+import javax.inject.Inject
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+class PushTokenRepositoryImpl
+    @Inject
+    constructor(
+        private val apiService: PushApiService,
+        private val pushPreferenceStorage: PushPreferenceStorage,
+    ) : PushTokenRepository {
+        override suspend fun registerCurrentToken(): Result<Unit> {
+            val currentToken =
+                runCatching { fetchCurrentToken() }
+                    .getOrElse { error ->
+                        Timber.e(error, "FCM 토큰 조회 실패")
+                        return Result.failure(error)
+                    }
+
+            // 콘솔에서 테스트 메시지를 보낼 때 토큰이 필요하므로 디버그 빌드에서만 출력한다.
+            if (BuildConfig.DEBUG) Timber.d("FCM token: %s", currentToken)
+
+            val lastRegisteredToken = pushPreferenceStorage.getLastRegisteredToken()
+            if (!PushTokenRegistrationPolicy.shouldRegister(currentToken, lastRegisteredToken)) {
+                Timber.d("이미 등록된 FCM 토큰이므로 서버 호출을 생략합니다.")
+                return Result.success(Unit)
+            }
+
+            return safeApiCall(
+                apiCall = { apiService.updateFcmToken(FcmTokenRequest(currentToken)) },
+                transform = { Unit },
+            ).onSuccess {
+                pushPreferenceStorage.saveLastRegisteredToken(currentToken)
+                Timber.d("FCM 토큰 등록 성공")
+            }.onFailure { error ->
+                Timber.e(error, "FCM 토큰 등록 실패")
+            }
+        }
+
+        private suspend fun fetchCurrentToken(): String =
+            suspendCancellableCoroutine { continuation ->
+                FirebaseMessaging
+                    .getInstance()
+                    .token
+                    .addOnSuccessListener { token -> continuation.resume(token) }
+                    .addOnFailureListener { error -> continuation.resumeWithException(error) }
+            }
+    }

--- a/app/src/main/java/com/egobook/app/di/module/DataStoreModule.kt
+++ b/app/src/main/java/com/egobook/app/di/module/DataStoreModule.kt
@@ -1,6 +1,7 @@
 package com.egobook.app.di.module
 
 import android.content.Context
+import com.egobook.app.data.local.PushPreferenceStorage
 import com.egobook.app.data.local.UserInfoStorage
 import dagger.Module
 import dagger.Provides
@@ -18,5 +19,11 @@ object DataStoreModule {
     fun provideUserTokenStorage(
         @ApplicationContext context: Context
     ): UserInfoStorage = UserInfoStorage(context)
+
+    @Provides
+    @Singleton
+    fun providePushPreferenceStorage(
+        @ApplicationContext context: Context
+    ): PushPreferenceStorage = PushPreferenceStorage(context)
 
 }

--- a/app/src/main/java/com/egobook/app/di/module/RepositoryModule.kt
+++ b/app/src/main/java/com/egobook/app/di/module/RepositoryModule.kt
@@ -9,6 +9,7 @@ import com.egobook.app.data.repository.account.AccountRepositoryImpl
 import com.egobook.app.data.repository.auth.AuthRepositoryImpl
 import com.egobook.app.data.repository.diary.CalenderRepositoryImpl
 import com.egobook.app.data.repository.diary.DiaryRepositoryImpl
+import com.egobook.app.data.repository.push.PushTokenRepositoryImpl
 import com.egobook.app.domain.repository.CounselingRepository
 import com.egobook.app.domain.repository.FriendsRepository
 import com.egobook.app.domain.repository.LetterRepository
@@ -18,6 +19,7 @@ import com.egobook.app.domain.repository.account.AccountRepository
 import com.egobook.app.domain.repository.auth.AuthRepository
 import com.egobook.app.domain.repository.diary.CalenderRepository
 import com.egobook.app.domain.repository.diary.DiaryRepository
+import com.egobook.app.domain.repository.push.PushTokenRepository
 import com.egobook.app.ui.home.repository.HomeNotificationRepository
 import com.egobook.app.ui.home.repository.NetworkHomeNotificationRepository
 import com.egobook.app.ui.home.repository.NetworkUserRepository
@@ -58,6 +60,10 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindAccountRepository(impl: AccountRepositoryImpl): AccountRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindPushTokenRepository(impl: PushTokenRepositoryImpl): PushTokenRepository
 
     @Binds
     @Singleton

--- a/app/src/main/java/com/egobook/app/di/module/ServiceModule.kt
+++ b/app/src/main/java/com/egobook/app/di/module/ServiceModule.kt
@@ -9,6 +9,7 @@ import com.egobook.app.data.api.DiaryApiService
 import com.egobook.app.data.api.FriendsApiService
 import com.egobook.app.data.api.LetterApiService
 import com.egobook.app.data.api.NotificationApiService
+import com.egobook.app.data.api.PushApiService
 import com.egobook.app.data.api.QuestionApiService
 import com.egobook.app.di.qualifier.AIApi
 import com.egobook.app.di.qualifier.AuthRetrofit
@@ -79,4 +80,9 @@ object ServiceModule {
     @Singleton
     fun provideCalenderService(@BackendApi retrofit: Retrofit): CalenderApiService =
         retrofit.create(CalenderApiService::class.java)
+
+    @Provides
+    @Singleton
+    fun providePushService(@BackendApi retrofit: Retrofit): PushApiService =
+        retrofit.create(PushApiService::class.java)
 }

--- a/app/src/main/java/com/egobook/app/domain/repository/push/PushTokenRepository.kt
+++ b/app/src/main/java/com/egobook/app/domain/repository/push/PushTokenRepository.kt
@@ -1,0 +1,9 @@
+package com.egobook.app.domain.repository.push
+
+interface PushTokenRepository {
+    /**
+     * 현재 기기의 FCM 토큰을 서버에 등록한다.
+     * 이미 등록된 토큰과 동일하면 서버를 호출하지 않고 성공으로 처리한다.
+     */
+    suspend fun registerCurrentToken(): Result<Unit>
+}

--- a/app/src/main/java/com/egobook/app/push/EgobookMessagingService.kt
+++ b/app/src/main/java/com/egobook/app/push/EgobookMessagingService.kt
@@ -1,0 +1,113 @@
+package com.egobook.app.push
+
+import android.Manifest
+import android.app.PendingIntent
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+import com.egobook.app.MainActivity
+import com.egobook.app.R
+import com.egobook.app.domain.repository.push.PushTokenRepository
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import java.util.concurrent.atomic.AtomicInteger
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class EgobookMessagingService : FirebaseMessagingService() {
+    @Inject
+    lateinit var pushTokenRepository: PushTokenRepository
+
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    override fun onDestroy() {
+        serviceScope.cancel()
+        super.onDestroy()
+    }
+
+    /**
+     * 토큰이 새로 발급되거나 갱신될 때 호출된다.
+     * 로그인 전이라면 등록에 실패하는데, 이 경우 홈 진입 시 재시도된다.
+     */
+    override fun onNewToken(token: String) {
+        Timber.d("FCM 토큰이 갱신되었습니다.")
+        serviceScope.launch {
+            pushTokenRepository.registerCurrentToken()
+        }
+    }
+
+    override fun onMessageReceived(message: RemoteMessage) {
+        val title = message.notification?.title ?: message.data[KEY_TITLE]
+        val body = message.notification?.body ?: message.data[KEY_BODY]
+
+        if (title == null && body == null) {
+            Timber.w("표시할 내용이 없는 메시지를 수신했습니다: %s", message.data)
+            return
+        }
+
+        showNotification(title, body)
+    }
+
+    private fun showNotification(
+        title: String?,
+        body: String?,
+    ) {
+        if (!hasPostNotificationPermission()) {
+            Timber.w("POST_NOTIFICATIONS 권한이 없어 알림을 표시하지 않습니다.")
+            return
+        }
+
+        val intent =
+            Intent(this, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
+            }
+        val pendingIntent =
+            PendingIntent.getActivity(
+                this,
+                0,
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            )
+
+        val notification =
+            NotificationCompat
+                .Builder(this, getString(R.string.default_notification_channel_id))
+                .setSmallIcon(R.drawable.ic_notification)
+                .setColor(ContextCompat.getColor(this, R.color.brand))
+                .setContentTitle(title)
+                .setContentText(body)
+                .setStyle(NotificationCompat.BigTextStyle().bigText(body))
+                .setContentIntent(pendingIntent)
+                .setAutoCancel(true)
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                .build()
+
+        NotificationManagerCompat
+            .from(this)
+            .notify(notificationId.incrementAndGet(), notification)
+    }
+
+    private fun hasPostNotificationPermission(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return true
+
+        return ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) ==
+            PackageManager.PERMISSION_GRANTED
+    }
+
+    companion object {
+        private const val KEY_TITLE = "title"
+        private const val KEY_BODY = "body"
+
+        private val notificationId = AtomicInteger(0)
+    }
+}

--- a/app/src/main/java/com/egobook/app/push/NotificationChannels.kt
+++ b/app/src/main/java/com/egobook/app/push/NotificationChannels.kt
@@ -1,0 +1,31 @@
+package com.egobook.app.push
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
+import androidx.core.content.getSystemService
+import com.egobook.app.R
+
+/**
+ * 앱에서 사용하는 알림 채널 정의.
+ *
+ * 채널은 생성 이후 중요도(importance)를 코드로 변경할 수 없으므로,
+ * 새로운 성격의 알림이 필요하면 기존 채널을 수정하지 말고 채널을 추가한다.
+ */
+object NotificationChannels {
+    fun createAll(context: Context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+
+        val manager = context.getSystemService<NotificationManager>() ?: return
+        val channel =
+            NotificationChannel(
+                context.getString(R.string.default_notification_channel_id),
+                context.getString(R.string.default_notification_channel_name),
+                NotificationManager.IMPORTANCE_DEFAULT,
+            ).apply {
+                description = context.getString(R.string.default_notification_channel_description)
+            }
+        manager.createNotificationChannel(channel)
+    }
+}

--- a/app/src/main/java/com/egobook/app/push/NotificationPermissionPolicy.kt
+++ b/app/src/main/java/com/egobook/app/push/NotificationPermissionPolicy.kt
@@ -1,0 +1,29 @@
+package com.egobook.app.push
+
+import android.os.Build
+
+enum class NotificationPermissionDecision {
+    REQUEST,
+    SKIP,
+}
+
+/**
+ * 알림 권한 요청 여부를 판단하는 정책.
+ *
+ * 안드로이드 13부터 두 번 거절하면 시스템이 권한 다이얼로그를 더 이상 띄우지 않으므로,
+ * 화면 진입마다 반복 요청하지 않고 최초 1회만 요청한다.
+ * 이미 요청한 뒤 거절한 사용자는 시스템 설정으로 유도한다.
+ */
+object NotificationPermissionPolicy {
+    fun decide(
+        sdkInt: Int,
+        isGranted: Boolean,
+        hasRequestedBefore: Boolean,
+    ): NotificationPermissionDecision {
+        if (sdkInt < Build.VERSION_CODES.TIRAMISU) return NotificationPermissionDecision.SKIP
+        if (isGranted) return NotificationPermissionDecision.SKIP
+        if (hasRequestedBefore) return NotificationPermissionDecision.SKIP
+
+        return NotificationPermissionDecision.REQUEST
+    }
+}

--- a/app/src/main/java/com/egobook/app/push/PushTokenRegistrationPolicy.kt
+++ b/app/src/main/java/com/egobook/app/push/PushTokenRegistrationPolicy.kt
@@ -1,0 +1,18 @@
+package com.egobook.app.push
+
+/**
+ * FCM 토큰을 서버에 등록할지 판단하는 정책.
+ *
+ * 홈 진입마다 동일한 토큰을 반복 전송하지 않도록,
+ * 마지막으로 등록에 성공한 토큰과 다를 때만 등록한다.
+ */
+object PushTokenRegistrationPolicy {
+    fun shouldRegister(
+        currentToken: String,
+        lastRegisteredToken: String?,
+    ): Boolean {
+        if (currentToken.isBlank()) return false
+
+        return currentToken != lastRegisteredToken
+    }
+}

--- a/app/src/main/java/com/egobook/app/ui/home/ui/HomeFragment.kt
+++ b/app/src/main/java/com/egobook/app/ui/home/ui/HomeFragment.kt
@@ -1,11 +1,16 @@
 package com.egobook.app.ui.home.ui
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
@@ -25,12 +30,30 @@ import com.egobook.app.ui.home.user.LevelType
 import com.egobook.app.store.ui.CustomItem
 import com.egobook.app.store.ui.ItemImage
 import com.egobook.app.store.data.model.ItemType
+import com.egobook.app.data.local.PushPreferenceStorage
+import com.egobook.app.domain.repository.push.PushTokenRepository
+import com.egobook.app.push.NotificationPermissionDecision
+import com.egobook.app.push.NotificationPermissionPolicy
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
+import javax.inject.Inject
+
 @AndroidEntryPoint
 class HomeFragment(): Fragment() {
     private lateinit var binding: FragmentHomeBinding
     private val redDotViewModel: NotificationRedDotViewModel by activityViewModels()
+
+    @Inject
+    lateinit var pushPreferenceStorage: PushPreferenceStorage
+
+    @Inject
+    lateinit var pushTokenRepository: PushTokenRepository
+
+    private val notificationPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+            Log.d("HomeFragment", "알림 권한 요청 결과: $isGranted")
+        }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -46,6 +69,8 @@ class HomeFragment(): Fragment() {
 
         viewModel.fetchUser()
         viewModel.fetchEquipItems()
+
+        setUpPushNotification()
         
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
@@ -175,6 +200,42 @@ class HomeFragment(): Fragment() {
             ItemType.BACKGROUND -> binding.ivHomeBackground.load(imagePath)
             ItemType.LETTER_PAPER -> {}
         }
+    }
+
+    /**
+     * 홈 진입 시 알림 권한을 요청하고, FCM 토큰을 서버에 등록한다.
+     *
+     * 권한을 거절해도 토큰 등록은 진행한다.
+     * 사용자가 나중에 시스템 설정에서 알림을 켜면 바로 수신할 수 있어야 하기 때문이다.
+     */
+    private fun setUpPushNotification() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            requestNotificationPermissionIfNeeded()
+            pushTokenRepository.registerCurrentToken()
+        }
+    }
+
+    private suspend fun requestNotificationPermissionIfNeeded() {
+        val decision =
+            NotificationPermissionPolicy.decide(
+                sdkInt = Build.VERSION.SDK_INT,
+                isGranted = isNotificationPermissionGranted(),
+                hasRequestedBefore = pushPreferenceStorage.hasRequestedPermissionBefore(),
+            )
+
+        if (decision == NotificationPermissionDecision.REQUEST) {
+            pushPreferenceStorage.markPermissionRequested()
+            notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+        }
+    }
+
+    private fun isNotificationPermissionGranted(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return true
+
+        return ContextCompat.checkSelfPermission(
+            requireContext(),
+            Manifest.permission.POST_NOTIFICATIONS,
+        ) == PackageManager.PERMISSION_GRANTED
     }
 
     private fun LevelType.getResId(): Int {

--- a/app/src/main/res/drawable/ic_notification.xml
+++ b/app/src/main/res/drawable/ic_notification.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:fillType="evenOdd"
+        android:pathData="M2.5,12.5a9.5,8 0 1,0 19,0a9.5,8 0 1,0 -19,0zM8.3,12.2a1.3,1.9 0 1,0 2.6,0a1.3,1.9 0 1,0 -2.6,0zM13.1,12.2a1.3,1.9 0 1,0 2.6,0a1.3,1.9 0 1,0 -2.6,0z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,4 +35,9 @@
 
     <!--  Home  -->
     <string name="home_bell_red_dot_description">읽지 않은 알림 있음</string>
+
+    <!--  Push Notification  -->
+    <string name="default_notification_channel_id" translatable="false">egobook_default</string>
+    <string name="default_notification_channel_name">에고북 알림</string>
+    <string name="default_notification_channel_description">에고북의 소식과 알림을 받아보세요</string>
 </resources>

--- a/app/src/test/java/com/egobook/app/push/NotificationPermissionPolicyTest.kt
+++ b/app/src/test/java/com/egobook/app/push/NotificationPermissionPolicyTest.kt
@@ -1,0 +1,67 @@
+package com.egobook.app.push
+
+import android.os.Build
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class NotificationPermissionPolicyTest {
+    @Test
+    fun `안드로이드 13 미만에서는 런타임 권한이 없으므로 요청하지 않는다`() {
+        val decision =
+            NotificationPermissionPolicy.decide(
+                sdkInt = Build.VERSION_CODES.S_V2,
+                isGranted = false,
+                hasRequestedBefore = false,
+            )
+
+        assertThat(decision).isEqualTo(NotificationPermissionDecision.SKIP)
+    }
+
+    @Test
+    fun `이미 권한이 허용되어 있으면 요청하지 않는다`() {
+        val decision =
+            NotificationPermissionPolicy.decide(
+                sdkInt = Build.VERSION_CODES.TIRAMISU,
+                isGranted = true,
+                hasRequestedBefore = false,
+            )
+
+        assertThat(decision).isEqualTo(NotificationPermissionDecision.SKIP)
+    }
+
+    @Test
+    fun `안드로이드 13 이상이고 권한이 없으며 요청한 적이 없으면 요청한다`() {
+        val decision =
+            NotificationPermissionPolicy.decide(
+                sdkInt = Build.VERSION_CODES.TIRAMISU,
+                isGranted = false,
+                hasRequestedBefore = false,
+            )
+
+        assertThat(decision).isEqualTo(NotificationPermissionDecision.REQUEST)
+    }
+
+    @Test
+    fun `이전에 요청한 적이 있으면 거절 상태여도 다시 요청하지 않는다`() {
+        val decision =
+            NotificationPermissionPolicy.decide(
+                sdkInt = Build.VERSION_CODES.TIRAMISU,
+                isGranted = false,
+                hasRequestedBefore = true,
+            )
+
+        assertThat(decision).isEqualTo(NotificationPermissionDecision.SKIP)
+    }
+
+    @Test
+    fun `요청한 적이 있어도 권한이 허용된 상태면 요청하지 않는다`() {
+        val decision =
+            NotificationPermissionPolicy.decide(
+                sdkInt = Build.VERSION_CODES.TIRAMISU,
+                isGranted = true,
+                hasRequestedBefore = true,
+            )
+
+        assertThat(decision).isEqualTo(NotificationPermissionDecision.SKIP)
+    }
+}

--- a/app/src/test/java/com/egobook/app/push/PushTokenRegistrationPolicyTest.kt
+++ b/app/src/test/java/com/egobook/app/push/PushTokenRegistrationPolicyTest.kt
@@ -1,0 +1,61 @@
+package com.egobook.app.push
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class PushTokenRegistrationPolicyTest {
+    @Test
+    fun `등록한 적이 없으면 서버에 등록한다`() {
+        val shouldRegister =
+            PushTokenRegistrationPolicy.shouldRegister(
+                currentToken = "token-a",
+                lastRegisteredToken = null,
+            )
+
+        assertThat(shouldRegister).isTrue()
+    }
+
+    @Test
+    fun `토큰이 갱신되었으면 서버에 다시 등록한다`() {
+        val shouldRegister =
+            PushTokenRegistrationPolicy.shouldRegister(
+                currentToken = "token-b",
+                lastRegisteredToken = "token-a",
+            )
+
+        assertThat(shouldRegister).isTrue()
+    }
+
+    @Test
+    fun `이미 등록한 토큰과 같으면 다시 등록하지 않는다`() {
+        val shouldRegister =
+            PushTokenRegistrationPolicy.shouldRegister(
+                currentToken = "token-a",
+                lastRegisteredToken = "token-a",
+            )
+
+        assertThat(shouldRegister).isFalse()
+    }
+
+    @Test
+    fun `토큰이 비어 있으면 등록하지 않는다`() {
+        val shouldRegister =
+            PushTokenRegistrationPolicy.shouldRegister(
+                currentToken = "",
+                lastRegisteredToken = null,
+            )
+
+        assertThat(shouldRegister).isFalse()
+    }
+
+    @Test
+    fun `토큰이 공백 문자로만 이루어져 있으면 등록하지 않는다`() {
+        val shouldRegister =
+            PushTokenRegistrationPolicy.shouldRegister(
+                currentToken = "   ",
+                lastRegisteredToken = "token-a",
+            )
+
+        assertThat(shouldRegister).isFalse()
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용

FCM 기반 서버 푸시 알림을 연동했습니다.

### 1. 수신 기반
- `firebase-messaging` 의존성 추가 (Firebase BOM에 포함되어 버전 명시 없음)
- `EgobookMessagingService` — 푸시 수신 및 `NotificationCompat`으로 알림 표시
- `NotificationChannels` — `MyApplication.onCreate()`에서 기본 채널 생성 (API 26+)
- `ic_notification.xml` — 알림 아이콘. 앱 아이콘(`ic_main_icon_foreground.webp`)은 불투명 래스터라 그대로 쓰면 상태바에 흰 사각형으로 표시되므로, 캐릭터 형태만 딴 단색 벡터를 새로 만들었습니다

### 2. 알림 권한 (Android 13+)
- 홈 진입 시 `POST_NOTIFICATIONS` 요청
- `NotificationPermissionPolicy` — **최초 1회만** 요청. 홈은 재진입이 잦은데 Android 13은 2회 거절 시 시스템이 다이얼로그를 영구 차단하므로 반복 요청이 손해입니다

### 3. FCM 토큰 서버 등록
- `PATCH /users/fcm-token` 연동 (`PushApiService` / `PushTokenRepository`)
- 등록 시점 2곳
  - `onNewToken` — 토큰 최초 발급·갱신 시. 로그인 전이면 실패하지만, 실패 시 이력을 저장하지 않아 다음 홈 진입에서 재시도됩니다
  - 홈 진입 시 — 로그인이 보장된 실질적 등록 경로
- `PushTokenRegistrationPolicy` — 마지막 등록 토큰과 같으면 서버 호출을 생략해 홈 진입마다 중복 전송하지 않습니다
- 로그아웃(`TokenAuthenticator`)·회원탈퇴 시 등록 이력 삭제. 삭제하지 않으면 다른 계정으로 재로그인했을 때 "토큰이 같다"는 이유로 등록이 생략되어 **이전 계정에게 알림이 가는** 문제가 생깁니다

## 🔗 관련 이슈
- Close #120

## 📸 스크린샷
- 실기기 발송 테스트를 아직 진행하지 않아 첨부하지 못했습니다.

## 💬 요구사항

### 백엔드와 합의가 필요한 부분
- **페이로드 형식**: 현재는 `notification` / `data` 양쪽을 모두 처리합니다. 다만 `notification` 페이로드는 앱이 백그라운드일 때 시스템이 직접 알림을 그려서 `onMessageReceived`가 호출되지 않습니다. 알림 탭 시 특정 화면으로 보내거나 내용을 앱에서 가공하려면 **`data`-only로 통일**해야 합니다.

### 남은 작업 (별도 이슈 제안)
- 알림 탭 시 딥링크 이동 — 현재는 종류와 무관하게 `MainActivity`로만 이동합니다. 알림별 목적지가 정해지면 `NavDeepLinkBuilder`로 구현 예정입니다.
- 권한을 거절한 사용자를 시스템 설정으로 유도하는 UI

### 확인 부탁드립니다
- Firebase 콘솔에서 **Cloud Messaging API(V1)** 활성화 여부
- 디버그 빌드에서만 토큰을 로그로 출력합니다(`if (BuildConfig.DEBUG)`). 콘솔 테스트 발송에 필요해서 넣었는데, 불필요하다면 제거하겠습니다.

## ✅ 체크리스트
- [x] 관련 없는 변경사항 삭제 했는가?
- [x] 테스트 여부 — 권한 요청 정책 5건, 토큰 등록 정책 5건 (`app/src/test/.../push/`)
- [ ] 실기기 푸시 수신 테스트 — **미진행**
- [ ] AGENTS.md 3단계 코드 리뷰(페르소나 3인) — **미진행**
