### PR TITLE
🐛Fix - 릴리즈 빌드 로그 노출 차단 (android.util.Log → Timber)

### DIFF
--- a/app/src/main/java/com/egobook/app/MainActivity.kt
+++ b/app/src/main/java/com/egobook/app/MainActivity.kt
@@ -1,7 +1,6 @@
 package com.egobook.app
 
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import android.widget.Toast
 import androidx.activity.enableEdgeToEdge
@@ -21,6 +20,7 @@ import com.google.android.gms.ads.rewarded.ServerSideVerificationOptions
 import dagger.hilt.android.AndroidEntryPoint
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 
 @AndroidEntryPoint
@@ -137,12 +137,12 @@ class MainActivity : AppCompatActivity(), BlurController, NotificationController
             override fun onAdFailedToLoad(adError: LoadAdError) {
                 rewardedAd = null
                 Toast.makeText(this@MainActivity, "광고를 불러오는데 실패했습니다", Toast.LENGTH_SHORT).show()
-                Log.d("AdMob", "광고 로드 실패, $adError")
+                Timber.d("광고 로드 실패, $adError")
             }
 
             override fun onAdLoaded(ad: RewardedAd) {
                 rewardedAd = ad
-                Log.d("AdMob", "광고 로드 성공!")
+                Timber.d("광고 로드 성공!")
             }
         })
     }
@@ -158,13 +158,13 @@ class MainActivity : AppCompatActivity(), BlurController, NotificationController
             rewardedAd?.show(this) { rewardItem ->
                 val rewardAmount = rewardItem.amount
                 val rewardType = rewardItem.type
-                Log.d("jang", "보상 지급! (서버로 콜백 날아감), $rewardType, rewardAmout: $rewardAmount")
+                Timber.d("보상 지급! (서버로 콜백 날아감), $rewardType, rewardAmout: $rewardAmount")
                 onAdClosed()
             }
             rewardedAd = null
             loadAd()
         } else {
-            Log.d("jang", "아직 광고가 준비 안 됐어요. 잠시 후 다시 시도해주세요.")
+            Timber.d("아직 광고가 준비 안 됐어요. 잠시 후 다시 시도해주세요.")
         }
     }
 

--- a/app/src/main/java/com/egobook/app/data/repository/diary/CalenderRepositoryImpl.kt
+++ b/app/src/main/java/com/egobook/app/data/repository/diary/CalenderRepositoryImpl.kt
@@ -1,6 +1,5 @@
 package com.egobook.app.data.repository.diary
 
-import android.util.Log
 import com.egobook.app.data.api.CalenderApiService
 import com.egobook.app.data.model.diary.response.CalenderData
 import com.egobook.app.data.util.safeApiCall
@@ -17,21 +16,12 @@ class CalenderRepositoryImpl @Inject constructor(
 
     override suspend fun getCalender(yearMonth: LocalDate): Result<List<CalenderDate>> {
         val monthString = yearMonth.format(DateTimeFormatter.ofPattern("yyyy-MM"))
-        Log.d("Repository", "Calling API with monthString: $monthString")
-
         val result = safeApiCall(
-            apiCall = { 
-                val response = apiService.getCalender(monthString)
-                Log.d("Repository", "Raw API Response - code: ${response.code}, data: ${response.data}")
-                response
-            },
+            apiCall = { apiService.getCalender(monthString) },
             transform = { calenderData: CalenderData ->
-                Log.d("Repository", "Transforming data: month=${calenderData.month}, days=${calenderData.days}")
                 CalenderMapper.dataToDomainList(calenderData)
             }
         )
-        
-        Log.d("Repository", "Result: $result")
         return result
     }
 }

--- a/app/src/main/java/com/egobook/app/domain/model/diary/mapper/CalenderMapper.kt
+++ b/app/src/main/java/com/egobook/app/domain/model/diary/mapper/CalenderMapper.kt
@@ -1,6 +1,5 @@
 package com.egobook.app.domain.model.diary.mapper
 
-import android.util.Log
 import com.egobook.app.data.model.diary.response.CalenderData
 import com.egobook.app.data.model.diary.response.CalenderDay
 import com.egobook.app.domain.model.calender.CalenderDate
@@ -16,7 +15,6 @@ object CalenderMapper {
      */
     fun dataToDomainList(calenderData: CalenderData): List<CalenderDate> {
         return calenderData.days?.map { day ->
-            Log.d("CalenderMapper", "Mapping day: date=${day.date}, emotionLevel=${day.emotionLevel}")
             dayToDomain(day)
         } ?: emptyList()
     }

--- a/app/src/main/java/com/egobook/app/store/ui/StoreFragment.kt
+++ b/app/src/main/java/com/egobook/app/store/ui/StoreFragment.kt
@@ -2,7 +2,6 @@ package com.egobook.app.store.ui
 
 import android.content.Context
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -25,6 +24,7 @@ import com.egobook.app.store.data.model.ItemType
 import com.google.android.material.tabs.TabLayoutMediator
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 @AndroidEntryPoint
 class StoreFragment: Fragment() {
@@ -82,7 +82,7 @@ class StoreFragment: Fragment() {
                 if (position == lastSelected) return
                 lastSelected = position
                 viewModel.clearPreviewItems()
-                Log.d("StoreFragment", "페이지 변경 감지됨: $position, 임시 착용 아이템 초기화")
+                Timber.d("페이지 변경 감지됨: $position, 임시 착용 아이템 초기화")
             }
         })
 

--- a/app/src/main/java/com/egobook/app/store/ui/StoreViewModel.kt
+++ b/app/src/main/java/com/egobook/app/store/ui/StoreViewModel.kt
@@ -1,6 +1,5 @@
 package com.egobook.app.store.ui
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.egobook.app.analytics.AnalyticsEvent
@@ -25,6 +24,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import timber.log.Timber
 
 data class CustomItemState(
     val isSelected: Boolean,
@@ -117,7 +117,7 @@ class StoreViewModel @Inject constructor(
             _permanentItems.value = permanent
             _equippedItems.value = permanent
         } catch (e: Exception) {
-            Log.e("StoreViewModel", "Store initialize failed", e)
+            Timber.e(e, "Store initialize failed")
             _toastEvent.emit("상점 정보를 불러오지 못했습니다.")
         } finally {
             hideLoading()
@@ -129,7 +129,7 @@ class StoreViewModel @Inject constructor(
             val user = userRepository.load()
             _ink.update { user.ink }
         } catch (e: Exception) {
-            Log.e("StoreViewModel", "Ink loading failed", e)
+            Timber.e(e, "Ink loading failed")
         }
     }
 
@@ -148,9 +148,9 @@ class StoreViewModel @Inject constructor(
                 val permanent = shopRepository.loadEquippedItems()
                 _permanentItems.value = permanent
                 _equippedItems.value = permanent
-                Log.d("StoreViewModel", "load: ${permanent}")
+                Timber.d("load: ${permanent}")
             } catch (e: Exception) {
-                Log.e("StoreViewModel", "Load equipped items failed", e)
+                Timber.e(e, "Load equipped items failed")
             } finally {
                 hideLoading()
             }
@@ -163,7 +163,7 @@ class StoreViewModel @Inject constructor(
             _equippedItems.update { currentList ->
                 currentList.filter { it.type != item.type } + item
             }
-            Log.d("StoreViewModel", "미구매 아이템 - 프리뷰 모드")
+            Timber.d("미구매 아이템 - 프리뷰 모드")
         } else {
             // 구매한 아이템: 서버에 장착/해제 요청 (토글)
             viewModelScope.launch {
@@ -180,9 +180,9 @@ class StoreViewModel @Inject constructor(
                             AnalyticsParam.ITEM_TYPE to item.type.name
                         )
                     )
-                    Log.d("StoreViewModel", "서버 착용 상태 변경 성공: ${item.id}, ${!isAlreadyEquipped}")
+                    Timber.d("서버 착용 상태 변경 성공: ${item.id}, ${!isAlreadyEquipped}")
                 } catch (e: Exception) {
-                    Log.e("StoreViewModel", "서버 통신 에러", e)
+                    Timber.e(e, "서버 통신 에러")
                     _toastEvent.emit("아이템(${item.id}) 상태 변경에 실패했습니다.")
                 } finally {
                     hideLoading()
@@ -227,7 +227,7 @@ class StoreViewModel @Inject constructor(
                 )
                 _toastEvent.emit("구매가 완료되었어요")
             } catch (e: Exception) {
-                Log.e("StoreViewModel", "Purchase failed", e)
+                Timber.e(e, "Purchase failed")
                 _toastEvent.emit("잉크가 부족하거나 구매에 실패했어요")
             } finally {
                 hideLoading()

--- a/app/src/main/java/com/egobook/app/ui/counseling/adapter/CounselingWeeklyReportAdapter.kt
+++ b/app/src/main/java/com/egobook/app/ui/counseling/adapter/CounselingWeeklyReportAdapter.kt
@@ -1,6 +1,5 @@
 package com.egobook.app.ui.counseling.adapter
 
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.paging.PagingDataAdapter
@@ -37,7 +36,6 @@ class CounselingWeeklyReportAdapter(private val onItemClick: (WeeklyReportModel)
 
     override fun onBindViewHolder(holder: WeeklyReportViewHolder, position: Int) {
         val item = getItem(position)
-        Log.e("TTEST", "pagingData adapter: $item")
         if(item != null) (holder.bind(item))
     }
 

--- a/app/src/main/java/com/egobook/app/ui/counseling/view/EgoRoomStatisticsFragment.kt
+++ b/app/src/main/java/com/egobook/app/ui/counseling/view/EgoRoomStatisticsFragment.kt
@@ -5,7 +5,6 @@ import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import android.text.Spannable
-import android.util.Log
 import android.text.SpannableStringBuilder
 import android.text.style.StyleSpan
 import android.view.View
@@ -47,6 +46,7 @@ import com.google.android.gms.ads.interstitial.InterstitialAdLoadCallback
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import kotlin.math.abs
+import timber.log.Timber
 
 @AndroidEntryPoint
 class EgoRoomStatisticsFragment : Fragment(R.layout.fragment_ego_room_statistics) {
@@ -78,13 +78,13 @@ class EgoRoomStatisticsFragment : Fragment(R.layout.fragment_ego_room_statistics
             object : InterstitialAdLoadCallback() {
                 override fun onAdLoaded(ad: InterstitialAd) {
                     interstitialAd = ad
-                    Log.d("AdMob", "통계 전면 광고 로드 성공")
+                    Timber.d("통계 전면 광고 로드 성공")
                     if (isResumed) showInterstitialAdIfReady()
                 }
 
                 override fun onAdFailedToLoad(adError: LoadAdError) {
                     interstitialAd = null
-                    Log.d("AdMob", "통계 전면 광고 로드 실패, $adError")
+                    Timber.d("통계 전면 광고 로드 실패, $adError")
                 }
             }
         )
@@ -97,7 +97,7 @@ class EgoRoomStatisticsFragment : Fragment(R.layout.fragment_ego_room_statistics
         interstitialAd = null
         ad.fullScreenContentCallback = object : FullScreenContentCallback() {
             override fun onAdFailedToShowFullScreenContent(adError: AdError) {
-                Log.d("AdMob", "통계 전면 광고 표시 실패, $adError")
+                Timber.d("통계 전면 광고 표시 실패, $adError")
             }
         }
         ad.show(requireActivity())

--- a/app/src/main/java/com/egobook/app/ui/counseling/view/WeeklyReportUnlockDialog.kt
+++ b/app/src/main/java/com/egobook/app/ui/counseling/view/WeeklyReportUnlockDialog.kt
@@ -3,7 +3,6 @@ package com.egobook.app.ui.counseling.view
 import android.app.Dialog
 import android.graphics.Color
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
@@ -29,6 +28,7 @@ import com.google.android.gms.ads.rewarded.RewardedAd
 import com.google.android.gms.ads.rewarded.RewardedAdLoadCallback
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 class WeeklyReportUnlockDialog(private val startDate: String): DialogFragment(R.layout.dialog_weekly_report_unlock) {
     private lateinit var binding: DialogWeeklyReportUnlockBinding
@@ -97,13 +97,13 @@ class WeeklyReportUnlockDialog(private val startDate: String): DialogFragment(R.
                 override fun onAdLoaded(ad: RewardedAd) {
                     isLoadingRewardedAd = false
                     rewardedAd = ad
-                    Log.d("AdMob", "주간 리포트 리워드 광고 로드 성공")
+                    Timber.d("주간 리포트 리워드 광고 로드 성공")
                 }
 
                 override fun onAdFailedToLoad(adError: LoadAdError) {
                     isLoadingRewardedAd = false
                     rewardedAd = null
-                    Log.d("AdMob", "주간 리포트 리워드 광고 로드 실패, $adError")
+                    Timber.d("주간 리포트 리워드 광고 로드 실패, $adError")
                 }
             }
         )

--- a/app/src/main/java/com/egobook/app/ui/diary/view/CalenderFragment.kt
+++ b/app/src/main/java/com/egobook/app/ui/diary/view/CalenderFragment.kt
@@ -2,7 +2,6 @@ package com.egobook.app.ui.diary.view
 
 import android.graphics.Color
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup

--- a/app/src/main/java/com/egobook/app/ui/diary/viewmodel/CalenderViewModel.kt
+++ b/app/src/main/java/com/egobook/app/ui/diary/viewmodel/CalenderViewModel.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.launch
 import java.time.LocalDate
 import java.time.YearMonth
 import javax.inject.Inject
-import android.util.Log
+import timber.log.Timber
 
 @HiltViewModel
 class CalenderViewModel @Inject constructor(
@@ -44,7 +44,7 @@ class CalenderViewModel @Inject constructor(
      * 초기 로드 - 외부에서 명시적으로 호출 필요
      */
     init {
-        Log.d("ViewModel1", "=== ViewModel INIT === selectedYearMonth=${_state.value.selectedYearMonth}")
+        Timber.d("=== ViewModel INIT === selectedYearMonth=${_state.value.selectedYearMonth}")
         // init에서 자동 로드하지 않음 - Fragment에서 초기 년월 설정 후 명시적 호출
     }
 
@@ -60,17 +60,17 @@ class CalenderViewModel @Inject constructor(
      */
     fun loadCalender(yearMonth: YearMonth) {
         viewModelScope.launch {
-            Log.d("ViewModel1", "=== loadCalender START === yearMonth=$yearMonth")
+            Timber.d("=== loadCalender START === yearMonth=$yearMonth")
 
             // YearMonth의 첫날을 LocalDate로 변환하여 API 호출
             val firstDayOfMonth = yearMonth.atDay(1)
-            Log.d("ViewModel1", "firstDayOfMonth=$firstDayOfMonth, calling API...")
+            Timber.d("firstDayOfMonth=$firstDayOfMonth, calling API...")
 
             calenderUseCases.getCalender(firstDayOfMonth)
                 .onSuccess { calenderDates ->
-                    Log.d("ViewModel1", "API Success, dates count: ${calenderDates.size}")
+                    Timber.d("API Success, dates count: ${calenderDates.size}")
                     val emotionMap = CalenderEntityMapper.toDateEmotionMap(calenderDates)
-                    Log.d("ViewModel1", "Map created with keys: ${emotionMap.keys}")
+                    Timber.d("Map created with keys: ${emotionMap.keys}")
                     _state.update { state ->
                         state.copy(
                             selectedYearMonth = yearMonth,
@@ -78,10 +78,10 @@ class CalenderViewModel @Inject constructor(
                             dateEmotionMap = emotionMap
                         )
                     }
-                    Log.d("ViewModel1", "State updated, current map keys: ${_state.value.dateEmotionMap.keys}")
+                    Timber.d("State updated, current map keys: ${_state.value.dateEmotionMap.keys}")
                 }
                 .onFailure { exception ->
-                    Log.e("ViewModel1", "API Failure: ${exception.message}", exception)
+                    Timber.e(exception, "API Failure: ${exception.message}")
                     // 실패해도 기존 데이터 유지, selectedYearMonth만 업데이트
                     _state.update { state ->
                         state.copy(
@@ -89,7 +89,7 @@ class CalenderViewModel @Inject constructor(
                         )
                     }
                 }
-            Log.d("ViewModel1", "=== loadCalender END ===")
+            Timber.d("=== loadCalender END ===")
         }
     }
 

--- a/app/src/main/java/com/egobook/app/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/egobook/app/ui/home/HomeViewModel.kt
@@ -1,6 +1,5 @@
 package com.egobook.app.ui.home
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.egobook.app.analytics.AnalyticsEvent
@@ -23,6 +22,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import timber.log.Timber
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
@@ -97,7 +97,7 @@ class HomeViewModel @Inject constructor(
             val user = userRepository.load()
             _uiState.value = user
         } catch(error: Exception) {
-            Log.e("HomeViewModel", "Failed to fetch user", error)
+            Timber.e(error, "Failed to fetch user")
         }
     }
 
@@ -119,7 +119,7 @@ class HomeViewModel @Inject constructor(
                 }
             }
         } catch (error: Exception) {
-            Log.e("HomeViewModel", "Failed to fetch tendencies", error)
+            Timber.e(error, "Failed to fetch tendencies")
         }
     }
 
@@ -127,7 +127,7 @@ class HomeViewModel @Inject constructor(
         try {
             _equippedItems.value = shopRepository.loadEquippedItems()
         } catch(error: Exception) {
-            Log.e("HomeViewModel", "Failed to fetch equip items", error)
+            Timber.e(error, "Failed to fetch equip items")
         }
     }
 
@@ -135,7 +135,7 @@ class HomeViewModel @Inject constructor(
         try {
             _dailyPhycologyReadState.value = psychologyRepository.isReadDailyPsychology()
         } catch(error: Exception) {
-            Log.e("HomeViewModel", "Failed to fetch psychology state", error)
+            Timber.e(error, "Failed to fetch psychology state")
         }
     }
 
@@ -178,7 +178,7 @@ class HomeViewModel @Inject constructor(
                 val adInfo = userAdRepository.loadAdInfo()
                 _adState.value = adInfo
             } catch (error: Exception) {
-                Log.e("HomeViewModel", "Failed to load ad info", error)
+                Timber.e(error, "Failed to load ad info")
             } finally {
                 _isLoadingAdInfo.value = false
             }
@@ -205,7 +205,7 @@ class HomeViewModel @Inject constructor(
                     AnalyticsEvent.AD_REWARD_WATCH,
                     mapOf(AnalyticsParam.AD_COUNT_TODAY to freshAdCount)
                 )
-                Log.d("HomeViewModel", "Ad watched: $message")
+                Timber.d("Ad watched: $message")
             } finally {
                 hideLoading()
             }

--- a/app/src/main/java/com/egobook/app/ui/home/NotificationRedDotViewModel.kt
+++ b/app/src/main/java/com/egobook/app/ui/home/NotificationRedDotViewModel.kt
@@ -1,6 +1,5 @@
 package com.egobook.app.ui.home
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.egobook.app.ui.home.notification.NotificationRedDotState
@@ -13,6 +12,7 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import timber.log.Timber
 
 @HiltViewModel
 class NotificationRedDotViewModel @Inject constructor(
@@ -28,7 +28,7 @@ class NotificationRedDotViewModel @Inject constructor(
                 val notifications = repository.loadNotifications().toList()
                 _redDotState.update { it.refreshed(notifications) }
             } catch (error: Exception) {
-                Log.e("NotificationRedDotViewModel", "Failed to refresh unread notifications", error)
+                Timber.e(error, "Failed to refresh unread notifications")
             }
         }
     }

--- a/app/src/main/java/com/egobook/app/ui/home/NotificationViewModel.kt
+++ b/app/src/main/java/com/egobook/app/ui/home/NotificationViewModel.kt
@@ -1,6 +1,5 @@
 package com.egobook.app.ui.home
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.egobook.app.analytics.AnalyticsEvent
@@ -15,6 +14,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import timber.log.Timber
 
 @HiltViewModel
 class NotificationViewModel @Inject constructor(
@@ -33,7 +33,6 @@ class NotificationViewModel @Inject constructor(
     }
 
     fun loadNotifications() {
-        Log.d("jang", "loadNotifications")
         viewModelScope.launch {
             val updatedList = mutableListOf<Notification>()
             repository.loadNotifications()
@@ -42,8 +41,6 @@ class NotificationViewModel @Inject constructor(
                     updatedList.add(notification)
                     _notifications.value = updatedList.toList()
 
-                    // 디버깅용 로그: 데이터가 실제로 오는지 확인
-                    Log.d("NotificationViewModel", "새 알림 수신: ${notification.content}")
                 }
         }
     }
@@ -51,7 +48,7 @@ class NotificationViewModel @Inject constructor(
     fun loadNotificationSetting() {
         viewModelScope.launch {
             val notificationSetting = repository.loadNotificationSetting()
-            Log.d("jang", "${notificationSetting}")
+            Timber.d("알림 설정 조회: enabled=${notificationSetting.enabled}")
             _notificationSettingState.value = notificationSetting
         }
     }
@@ -59,7 +56,7 @@ class NotificationViewModel @Inject constructor(
     fun changeNotificationSetting() {
         viewModelScope.launch {
             val notificationSetting = repository.changeNotificationSetting()
-            Log.d("jang", "${notificationSetting}")
+            Timber.d("알림 설정 변경: enabled=${notificationSetting.enabled}")
             _notificationSettingState.value = notificationSetting
             analyticsLogger.logEvent(
                 AnalyticsEvent.NOTIFICATION_TOGGLE,
@@ -71,7 +68,7 @@ class NotificationViewModel @Inject constructor(
     fun readNotification(notification: Notification) {
         viewModelScope.launch {
             val notificationReadingDto = repository.readNotification(notification)
-            Log.d("jang", "${notificationReadingDto}")
+            Timber.d("알림 읽음 처리 완료: id=${notification.id}")
             analyticsLogger.logEvent(
                 AnalyticsEvent.NOTIFICATION_OPEN,
                 mapOf(AnalyticsParam.NOTIFICATION_TYPE to (notification.type::class.simpleName ?: "unknown"))

--- a/app/src/main/java/com/egobook/app/ui/home/repository/HomeNotificationRepository.kt
+++ b/app/src/main/java/com/egobook/app/ui/home/repository/HomeNotificationRepository.kt
@@ -1,6 +1,5 @@
 package com.egobook.app.ui.home.repository
 
-import android.util.Log
 import com.egobook.app.di.qualifier.BackendApi
 import com.egobook.app.ui.home.notification.EgoRoomType
 import com.egobook.app.ui.home.notification.Notification
@@ -20,6 +19,7 @@ import retrofit2.http.Query
 import java.time.LocalDateTime
 import javax.inject.Inject
 import javax.inject.Singleton
+import timber.log.Timber
 
 interface HomeNotificationRepository {
     suspend fun loadNotifications(): Flow<Notification>
@@ -124,7 +124,6 @@ class NetworkHomeNotificationRepository @Inject constructor(
                     ).data
 
                     response.content.forEach { dto ->
-                        Log.d("jang", "$dto")
                         emit(dto.toDomain())
                     }
 
@@ -134,10 +133,7 @@ class NetworkHomeNotificationRepository @Inject constructor(
                     currentPage++
 
                 } catch (e: Exception) {
-                    Log.e(
-                        "jang",
-                        "페이지 $currentPage 로드 중 에러 발생: $e"
-                    )
+                    Timber.e(e, "페이지 $currentPage 로드 중 에러 발생")
                     break
                 }
             }
@@ -150,7 +146,7 @@ class NetworkHomeNotificationRepository @Inject constructor(
 
     override suspend fun changeNotificationSetting(): NotificationSettingDto {
         val notificationChangeDto = notificationService.changeNotificationSetting().data
-        Log.d("jang2", "${notificationChangeDto}")
+        Timber.d("알림 설정 변경 응답: enabled=${notificationChangeDto.enabled}")
         return NotificationSettingDto(notificationChangeDto.enabled)
     }
 

--- a/app/src/main/java/com/egobook/app/ui/home/repository/UserRepository.kt
+++ b/app/src/main/java/com/egobook/app/ui/home/repository/UserRepository.kt
@@ -1,6 +1,5 @@
 package com.egobook.app.ui.home.repository
 
-import android.util.Log
 import com.egobook.app.di.qualifier.BackendApi
 import com.egobook.app.ui.home.user.Tendency
 import com.egobook.app.ui.home.user.User
@@ -192,7 +191,6 @@ class NetworkUserRepository @Inject constructor(
     override suspend fun isReadDailyPsychology(): Boolean {
         val psychologyResponse: BaseResponse<PsychologyStateDto> =
             psychologyService.isReadDailyPsychology()
-        Log.d("jang", "isReadDailyPsychology: ${psychologyResponse.data.isBottleVisible}")
         return psychologyResponse.data.isBottleVisible
     }
 

--- a/app/src/main/java/com/egobook/app/ui/home/ui/HomeFragment.kt
+++ b/app/src/main/java/com/egobook/app/ui/home/ui/HomeFragment.kt
@@ -1,7 +1,6 @@
 package com.egobook.app.ui.home.ui
 
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -27,6 +26,7 @@ import com.egobook.app.store.ui.ItemImage
 import com.egobook.app.store.data.model.ItemType
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
+import timber.log.Timber
 @AndroidEntryPoint
 class HomeFragment(): Fragment() {
     private lateinit var binding: FragmentHomeBinding
@@ -105,7 +105,7 @@ class HomeFragment(): Fragment() {
             viewModel.logPsychKnowledgeOpen()
 
             parentFragmentManager.setFragmentResultListener("psychology_key", viewLifecycleOwner) { _, _ ->
-                Log.d("jang", "다이얼로그 닫힘 감지 - 데이터 갱신")
+                Timber.d("다이얼로그 닫힘 감지 - 데이터 갱신")
                 viewModel.fetchUser()
                 viewModel.fetchDailyPhycologyReadState()
             }

--- a/app/src/main/java/com/egobook/app/ui/home/ui/NotificationFragment.kt
+++ b/app/src/main/java/com/egobook/app/ui/home/ui/NotificationFragment.kt
@@ -1,7 +1,6 @@
 package com.egobook.app.ui.home.ui
 
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -18,6 +17,7 @@ import com.egobook.app.ui.home.notification.NotificationType
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 @AndroidEntryPoint
 class NotificationFragment: Fragment() {
@@ -73,7 +73,7 @@ class NotificationFragment: Fragment() {
 
                 launch {
                     viewModel.notificationSettingState.collect { notificationSettingState ->
-                        Log.d("jang", "UI에서 감지된 설정: ${notificationSettingState}")
+                        Timber.d("UI에서 감지된 설정: ${notificationSettingState}")
                         if (notificationSettingState.enabled) {
                             binding.ivHomeNotificationButton.setImageResource(R.drawable.ic_notification_on)
                         } else {

--- a/app/src/main/java/com/egobook/app/ui/home/ui/StreakDialog.kt
+++ b/app/src/main/java/com/egobook/app/ui/home/ui/StreakDialog.kt
@@ -3,7 +3,6 @@ package com.egobook.app.ui.home.ui
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -23,6 +22,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.time.LocalDate
+import timber.log.Timber
 
 @AndroidEntryPoint
 class StreakDialog : DialogFragment() {
@@ -144,7 +144,7 @@ class StreakDialog : DialogFragment() {
                 }
 
             } catch (e: Exception) {
-                Log.d("error", e.toString())
+                Timber.e(e, "스트릭 정보 조회 실패")
             }
         }
         binding.ivClose.setOnClickListener {


### PR DESCRIPTION
## 📝 작업 내용

`android.util.Log`는 Timber 설정과 무관하게 동작해 릴리즈 빌드에서도 logcat에 그대로 출력되고 있었습니다. 모든 로깅을 Timber로 일원화해 DEBUG 빌드에서만 로그가 남도록 정리했습니다. (`MyApplication`에서 `BuildConfig.DEBUG`일 때만 `Timber.plant()` 하므로 릴리즈에서는 no-op)

- `android.util.Log` 호출 **51건 / 18개 파일** 을 Timber로 전면 치환
  - `Log.d(tag, msg)` → `Timber.d(msg)` (태그는 Timber DebugTree가 처리)
  - `Log.e(tag, msg, throwable)` → `Timber.e(throwable, msg)` (Timber 인자 순서에 맞춤)
- 예외를 문자열로 이어붙이던 로그(`"...: $e"`)는 throwable 인자로 정정 → **스택트레이스 보존**
- 임시/민감 디버깅 로그는 치환이 아니라 **삭제**
  - `CalenderRepositoryImpl` — API 원본 응답 전체 덤프(`Raw API Response - code/data`) 포함 4건 삭제, `apiCall` 람다 정리
  - `UserRepository` / `HomeNotificationRepository`의 `Log.d("jang", ...)`, `Log.d("jang2", ...)`, `CounselingWeeklyReportAdapter`의 `Log.e("TTEST", ...)`, `CalenderMapper` 반복 매핑 로그 삭제
- `Timber.d("${notificationSetting}")` 같은 무의미한 객체 덤프는 필요한 필드만 남긴 메시지로 교체
- `Log.d(e.toString())` → `Timber.e(e, "스트릭 정보 조회 실패")`
- 잔여 `import android.util.Log` 및 로그 삭제로 미사용이 된 `Timber` import 정리

## 🔗 관련 이슈
- Fix #123

## 📸 스크린샷
- UI 변경 없음

## 💬 요구사항(선택)
- 삭제한 로그 중 디버깅에 계속 필요한 게 있다면 알려주세요. Timber 치환으로 되돌리겠습니다.
- 이슈의 **선택 항목**은 이번 PR 범위에서 제외했습니다. 별도 이슈로 다루는 게 좋아 보입니다.
  - `release`에 `isMinifyEnabled = true` + ProGuard `assumenosideeffects` — 난독화 활성화는 리플렉션/직렬화 런타임 회귀 위험이 있어 단독 검증이 필요
  - CI grep 체크 / Lint 커스텀 룰로 `android.util.Log` 신규 유입 차단

## ✅ 체크리스트
- [x] 관련 없는 변경사항 삭제 했는가? (불필요한 주석, 로그 등)
- [x] `:app:compileDebugKotlin` / `:app:compileReleaseKotlin` 컴파일 통과 확인
- [ ] 실기기 `assembleRelease` 후 logcat 무출력 검증 — 로컬에 서명 키/`google-services.json`이 없어 미수행

🤖 Generated with [Claude Code](https://claude.com/claude-code)