### PR TITLE
[✨Feat] 회원탈퇴 사유 선택 기능 구현

### DIFF
--- a/app/src/main/java/com/egobook/app/data/api/AccountApiService.kt
+++ b/app/src/main/java/com/egobook/app/data/api/AccountApiService.kt
@@ -5,6 +5,7 @@ import com.egobook.app.data.model.account.AccountResponse
 import com.egobook.app.data.model.account.DeleteAccountResponse
 import com.egobook.app.data.model.account.LinkRequest
 import com.egobook.app.data.model.account.LinkResponse
+import com.egobook.app.data.model.account.WithdrawReasonRequest
 import com.google.gson.JsonElement
 import retrofit2.http.GET
 import retrofit2.http.Body
@@ -25,6 +26,12 @@ interface AccountApiService {
 
     @DELETE("/users/withdraw")
     suspend fun deleteAccount(): ApiResponse<DeleteAccountResponse>
+
+    // 탈퇴 사유 저장. 반드시 deleteAccount() 호출 이전에 호출해야 저장된다.
+    @POST("/users/withdraw/reason")
+    suspend fun submitWithdrawReason(
+        @Body request: WithdrawReasonRequest
+    ): ApiResponse<JsonElement?>
 
     // data 필드가 문자열/객체/null 어느 것이든 Gson이 파싱 가능하도록 JsonElement? 사용
     @PATCH("/users/nickname")

--- a/app/src/main/java/com/egobook/app/data/model/account/WithdrawReasonRequest.kt
+++ b/app/src/main/java/com/egobook/app/data/model/account/WithdrawReasonRequest.kt
@@ -1,0 +1,13 @@
+package com.egobook.app.data.model.account
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WithdrawReasonRequest(
+    @SerialName("reasonType")
+    val reasonType: String,
+
+    @SerialName("text")
+    val text: String? = null,
+)

--- a/app/src/main/java/com/egobook/app/data/repository/account/AccountRepositoryImpl.kt
+++ b/app/src/main/java/com/egobook/app/data/repository/account/AccountRepositoryImpl.kt
@@ -4,6 +4,8 @@ import com.egobook.app.data.api.AccountApiService
 import com.egobook.app.data.local.UserInfoStorage
 import com.egobook.app.data.model.account.LinkRequest
 import com.egobook.app.data.model.account.NicknameRequest
+import com.egobook.app.data.model.account.WithdrawReasonRequest
+import com.egobook.app.domain.model.account.WithdrawReasonType
 import com.egobook.app.data.util.safeApiCall
 import com.egobook.app.data.util.safeAuthApiCall
 import com.egobook.app.domain.repository.account.AccountRepository
@@ -83,6 +85,24 @@ class AccountRepositoryImpl @Inject constructor(
                 email = email,
                 isGoogleLinked = isGoogleLinked
             )
+        )
+    }
+
+    override suspend fun submitWithdrawReason(
+        reasonType: WithdrawReasonType,
+        text: String?
+    ): Result<Unit> {
+        return safeApiCall(
+            apiCall = {
+                apiService.submitWithdrawReason(
+                    WithdrawReasonRequest(
+                        reasonType = reasonType.value,
+                        // 기타가 아닌 경우 상세 사유를 보내지 않는다
+                        text = if (reasonType == WithdrawReasonType.OTHER) text?.trim() else null
+                    )
+                )
+            },
+            transform = { Unit }
         )
     }
 

--- a/app/src/main/java/com/egobook/app/domain/model/account/WithdrawReasonType.kt
+++ b/app/src/main/java/com/egobook/app/domain/model/account/WithdrawReasonType.kt
@@ -1,0 +1,19 @@
+package com.egobook.app.domain.model.account
+
+/**
+ * 회원 탈퇴 사유 유형
+ *
+ * [value]는 서버(`POST /users/withdraw/reason`)에 전달하는 ENUM 값이다.
+ */
+enum class WithdrawReasonType(val value: String) {
+    NOT_USED_OFTEN("NOT_USED_OFTEN"),
+    LACK_OF_CONTENT("LACK_OF_CONTENT"),
+    INCONVENIENT_UI("INCONVENIENT_UI"),
+    DIFFICULT_TO_COLLECT_INK("DIFFICULT_TO_COLLECT_INK"),
+    OTHER("OTHER");
+
+    companion object {
+        /** 기타 선택 시 입력 가능한 상세 사유 최대 길이 */
+        const val MAX_TEXT_LENGTH = 500
+    }
+}

--- a/app/src/main/java/com/egobook/app/domain/repository/account/AccountRepository.kt
+++ b/app/src/main/java/com/egobook/app/domain/repository/account/AccountRepository.kt
@@ -1,5 +1,7 @@
 package com.egobook.app.domain.repository.account
 
+import com.egobook.app.domain.model.account.WithdrawReasonType
+
 interface AccountRepository {
 
     /**
@@ -16,6 +18,18 @@ interface AccountRepository {
      * 로컬에서 게스트타입과 GOOGLE이면 email을 읽어오는 로직
      */
     suspend fun getLinkedAccountInfo(): Result<LinkedAccountInfo>
+
+    /**
+     * 탈퇴 사유 저장
+     *
+     * 서버 정책상 [deleteAccount] 호출 이전에 먼저 호출해야 저장된다.
+     *
+     * @param text 기타(OTHER) 선택 시 입력한 상세 사유
+     */
+    suspend fun submitWithdrawReason(
+        reasonType: WithdrawReasonType,
+        text: String? = null
+    ): Result<Unit>
 
     /**
      * 계정 탈퇴

--- a/app/src/main/java/com/egobook/app/ui/account/view/AccountDeleteDialog1Fragment.kt
+++ b/app/src/main/java/com/egobook/app/ui/account/view/AccountDeleteDialog1Fragment.kt
@@ -9,14 +9,9 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import com.egobook.app.databinding.FragmentAccountDeleteDialog1Binding
 import com.egobook.app.removeScreenBlur
 import com.egobook.app.ui.account.viewmodel.AccountViewModel
-import com.egobook.app.util.UiState
-import kotlinx.coroutines.launch
 
 class AccountDeleteDialog1Fragment : DialogFragment() {
 
@@ -39,7 +34,6 @@ class AccountDeleteDialog1Fragment : DialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setClickListener()
-        observeDeleteAccountState()
     }
 
     private fun setClickListener() {
@@ -48,32 +42,16 @@ class AccountDeleteDialog1Fragment : DialogFragment() {
             dismiss()
         }
         binding.btnRealDelete.setOnClickListener {
-            viewModel.deleteAccount()
+            navigateToDeleteReasonDialog()
         }
     }
 
-    private fun observeDeleteAccountState() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.deleteAccountState.collect { state ->
-                    when (state) {
-                        is UiState.Success -> {
-                            navigateToDeleteDialog2()
-                        }
-                        is UiState.Failure -> {
-                            // TODO: 실패 처리 (토스트 메시지 등)
-                        }
-                        else -> {}
-                    }
-                }
-            }
-        }
-    }
+    private fun navigateToDeleteReasonDialog() {
+        viewModel.resetWithdrawReason()
 
-    private fun navigateToDeleteDialog2() {
-        val accountDeleteDialog2Fragment = AccountDeleteDialog2Fragment()
-        accountDeleteDialog2Fragment.isCancelable = true
-        accountDeleteDialog2Fragment.show(parentFragmentManager, "AccountDeleteDialog2Fragment")
+        val reasonDialogFragment = AccountDeleteReasonDialogFragment()
+        reasonDialogFragment.isCancelable = true
+        reasonDialogFragment.show(parentFragmentManager, "AccountDeleteReasonDialogFragment")
         dismiss()
     }
 

--- a/app/src/main/java/com/egobook/app/ui/account/view/AccountDeleteDialog2Fragment.kt
+++ b/app/src/main/java/com/egobook/app/ui/account/view/AccountDeleteDialog2Fragment.kt
@@ -11,10 +11,13 @@ import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
 import com.egobook.app.databinding.FragmentAccountDeleteDialog2Binding
 import com.egobook.app.removeScreenBlur
 import com.egobook.app.ui.account.viewmodel.AccountViewModel
 import com.egobook.app.ui.login.view.LoginActivity
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import timber.log.Timber
 import kotlin.getValue
 
@@ -25,6 +28,8 @@ class AccountDeleteDialog2Fragment : DialogFragment() {
 
     //부모 프래그먼트의 뷰모델 공유
     private val viewModel: AccountViewModel by viewModels({ requireParentFragment() })
+
+    private var hasNavigated = false
 
 
     override fun onCreateView(
@@ -39,12 +44,25 @@ class AccountDeleteDialog2Fragment : DialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        // TODO: 뷰 초기화 로직 추가
+
+        // 버튼이 없는 안내 다이얼로그이므로 잠시 인사말을 보여준 뒤 스스로 닫는다
+        viewLifecycleOwner.lifecycleScope.launch {
+            delay(AUTO_DISMISS_DELAY_MS)
+            navigateToLogin()
+            dismissAllowingStateLoss()
+        }
     }
 
-
+    /** 사용자가 먼저 다이얼로그를 닫는 경우 */
     override fun onCancel(dialog: DialogInterface) {
         super.onCancel(dialog)
+        navigateToLogin()
+    }
+
+    private fun navigateToLogin() {
+        // 자동 닫힘과 사용자 조작이 겹쳐도 한 번만 이동한다
+        if (hasNavigated) return
+        hasNavigated = true
 
         //백스택 제거 후 로그인 화면으로 이동
         val intent = Intent(context, LoginActivity::class.java).apply {
@@ -59,6 +77,11 @@ class AccountDeleteDialog2Fragment : DialogFragment() {
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    companion object {
+        /** 인사말을 읽을 수 있도록 두는 시간 */
+        private const val AUTO_DISMISS_DELAY_MS = 2_000L
     }
 
 

--- a/app/src/main/java/com/egobook/app/ui/account/view/AccountDeleteReasonDialogFragment.kt
+++ b/app/src/main/java/com/egobook/app/ui/account/view/AccountDeleteReasonDialogFragment.kt
@@ -1,0 +1,155 @@
+package com.egobook.app.ui.account.view
+
+import android.content.DialogInterface
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import android.widget.Toast
+import androidx.core.widget.doAfterTextChanged
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.egobook.app.databinding.FragmentAccountDeleteReasonDialogBinding
+import com.egobook.app.domain.model.account.WithdrawReasonType
+import com.egobook.app.removeScreenBlur
+import com.egobook.app.ui.account.viewmodel.AccountViewModel
+import com.egobook.app.util.UiState
+import kotlinx.coroutines.launch
+
+/**
+ * 탈퇴 이유 선택 다이얼로그.
+ *
+ * [AccountDeleteDialog1Fragment]에서 탈퇴를 확정한 뒤 노출되며,
+ * 사유 저장 → 회원 탈퇴가 끝나면 [AccountDeleteDialog2Fragment]로 넘어간다.
+ */
+class AccountDeleteReasonDialogFragment : DialogFragment() {
+
+    private var _binding: FragmentAccountDeleteReasonDialogBinding? = null
+    private val binding get() = _binding!!
+
+    //부모 프래그먼트의 뷰모델 공유
+    private val viewModel: AccountViewModel by viewModels({ requireParentFragment() })
+
+    private val reasonViews: List<Pair<WithdrawReasonType, TextView>>
+        get() = listOf(
+            WithdrawReasonType.NOT_USED_OFTEN to binding.tvReasonNotUsedOften,
+            WithdrawReasonType.LACK_OF_CONTENT to binding.tvReasonLackOfContent,
+            WithdrawReasonType.INCONVENIENT_UI to binding.tvReasonInconvenientUi,
+            WithdrawReasonType.DIFFICULT_TO_COLLECT_INK to binding.tvReasonDifficultToCollectInk,
+            WithdrawReasonType.OTHER to binding.tvReasonOther,
+        )
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+        _binding = FragmentAccountDeleteReasonDialogBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setClickListener()
+        setTextChangeListener()
+        observeSelectedReason()
+        observeDeleteAccountState()
+        observeWithdrawToastEvent()
+    }
+
+    private fun setClickListener() {
+        reasonViews.forEach { (reason, textView) ->
+            textView.setOnClickListener { viewModel.selectWithdrawReason(reason) }
+        }
+
+        binding.btnBack.setOnClickListener {
+            viewModel.resetWithdrawReason()
+            removeScreenBlur()
+            dismiss()
+        }
+
+        binding.btnRealDelete.setOnClickListener {
+            viewModel.deleteAccount()
+        }
+    }
+
+    private fun setTextChangeListener() {
+        binding.etOtherReason.doAfterTextChanged { editable ->
+            viewModel.updateWithdrawReasonText(editable?.toString().orEmpty())
+        }
+    }
+
+    private fun observeSelectedReason() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.selectedWithdrawReason.collect { selected ->
+                    renderSelection(selected)
+                }
+            }
+        }
+    }
+
+    private fun renderSelection(selected: WithdrawReasonType?) {
+        reasonViews.forEach { (reason, textView) ->
+            textView.isSelected = reason == selected
+        }
+
+        // 기타를 고르면 항목 자리에 상세 사유 입력 영역을 대신 노출한다
+        val isOther = selected == WithdrawReasonType.OTHER
+        binding.tvReasonOther.visibility = if (isOther) View.GONE else View.VISIBLE
+        binding.dividerOther.visibility = if (isOther) View.GONE else View.VISIBLE
+        binding.layoutOtherInput.visibility = if (isOther) View.VISIBLE else View.GONE
+
+        if (!isOther && binding.etOtherReason.text.isNotEmpty()) {
+            binding.etOtherReason.setText("")
+        }
+    }
+
+    private fun observeDeleteAccountState() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.deleteAccountState.collect { state ->
+                    binding.btnRealDelete.isEnabled = state !is UiState.Loading
+                    if (state is UiState.Success) {
+                        navigateToDeleteDialog2()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun observeWithdrawToastEvent() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.withdrawToastEvent.collect { message ->
+                    Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
+
+    private fun navigateToDeleteDialog2() {
+        val accountDeleteDialog2Fragment = AccountDeleteDialog2Fragment()
+        accountDeleteDialog2Fragment.isCancelable = true
+        accountDeleteDialog2Fragment.show(parentFragmentManager, "AccountDeleteDialog2Fragment")
+        dismiss()
+    }
+
+    override fun onCancel(dialog: DialogInterface) {
+        super.onCancel(dialog)
+        viewModel.resetWithdrawReason()
+        removeScreenBlur()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/egobook/app/ui/account/view/AccountDeleteReasonDialogFragment.kt
+++ b/app/src/main/java/com/egobook/app/ui/account/view/AccountDeleteReasonDialogFragment.kt
@@ -20,6 +20,7 @@ import com.egobook.app.domain.model.account.WithdrawReasonType
 import com.egobook.app.removeScreenBlur
 import com.egobook.app.ui.account.viewmodel.AccountViewModel
 import com.egobook.app.util.UiState
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 
 /**
@@ -115,8 +116,21 @@ class AccountDeleteReasonDialogFragment : DialogFragment() {
     private fun observeDeleteAccountState() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                // 사유를 다 고르고 탈퇴 요청 중이 아닐 때만 탈퇴하기를 누를 수 있다
+                combine(
+                    viewModel.isWithdrawReasonValid,
+                    viewModel.deleteAccountState
+                ) { isValid, state ->
+                    isValid && state !is UiState.Loading
+                }.collect { isEnabled ->
+                    binding.btnRealDelete.isEnabled = isEnabled
+                }
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.deleteAccountState.collect { state ->
-                    binding.btnRealDelete.isEnabled = state !is UiState.Loading
                     if (state is UiState.Success) {
                         navigateToDeleteDialog2()
                     }

--- a/app/src/main/java/com/egobook/app/ui/account/view/AccountDeleteReasonDialogFragment.kt
+++ b/app/src/main/java/com/egobook/app/ui/account/view/AccountDeleteReasonDialogFragment.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.WindowManager
 import android.widget.TextView
 import android.widget.Toast
 import androidx.core.widget.doAfterTextChanged
@@ -54,6 +55,19 @@ class AccountDeleteReasonDialogFragment : DialogFragment() {
         dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
         _binding = FragmentAccountDeleteReasonDialogBinding.inflate(inflater, container, false)
         return binding.root
+    }
+
+    override fun onStart() {
+        super.onStart()
+        // DialogFragment 기본 창 폭이 좁아 항목 텍스트가 눌리므로 화면 폭에 맞춰 넓힌다
+        val horizontalMarginPx = (DIALOG_HORIZONTAL_MARGIN_DP * resources.displayMetrics.density).toInt()
+        dialog?.window?.apply {
+            val screenWidth = context.resources.displayMetrics.widthPixels
+            setLayout(
+                screenWidth - horizontalMarginPx * 2,
+                WindowManager.LayoutParams.WRAP_CONTENT
+            )
+        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -165,5 +179,9 @@ class AccountDeleteReasonDialogFragment : DialogFragment() {
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    companion object {
+        private const val DIALOG_HORIZONTAL_MARGIN_DP = 24
     }
 }

--- a/app/src/main/java/com/egobook/app/ui/account/viewmodel/AccountViewModel.kt
+++ b/app/src/main/java/com/egobook/app/ui/account/viewmodel/AccountViewModel.kt
@@ -53,17 +53,24 @@ class AccountViewModel @Inject constructor(
     private val _withdrawToastEvent = MutableSharedFlow<String>(replay = 0)
     val withdrawToastEvent = _withdrawToastEvent.asSharedFlow()
 
-    /** 사유를 골랐고, 기타인 경우 상세 사유까지 입력했는지 */
+    /**
+     * 사유를 골랐고, 기타인 경우 상세 사유까지 입력했는지
+     *
+     * 구독자가 없는 동안에도 [deleteAccount]가 최신 값을 읽어야 하므로 Eagerly로 공유한다.
+     */
     val isWithdrawReasonValid = combine(
         _selectedWithdrawReason,
         _withdrawReasonText
     ) { reason, text ->
+        isReasonValid(reason, text)
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, false)
+
+    private fun isReasonValid(reason: WithdrawReasonType?, text: String): Boolean =
         when (reason) {
             null -> false
             WithdrawReasonType.OTHER -> text.isNotBlank()
             else -> true
         }
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
 
     private val _nickname = MutableStateFlow<String?>(null)
     val nickname = _nickname.asStateFlow()
@@ -209,7 +216,7 @@ class AccountViewModel @Inject constructor(
      */
     fun deleteAccount() {
         val reason = _selectedWithdrawReason.value
-        if (reason == null || !isWithdrawReasonValid.value) {
+        if (reason == null || !isReasonValid(reason, _withdrawReasonText.value)) {
             viewModelScope.launch {
                 _withdrawToastEvent.emit(
                     if (reason == WithdrawReasonType.OTHER) "탈퇴 사유를 작성해 주세요"

--- a/app/src/main/java/com/egobook/app/ui/account/viewmodel/AccountViewModel.kt
+++ b/app/src/main/java/com/egobook/app/ui/account/viewmodel/AccountViewModel.kt
@@ -6,15 +6,20 @@ import com.egobook.app.analytics.AnalyticsEvent
 import com.egobook.app.analytics.AnalyticsLogger
 import com.egobook.app.domain.model.account.NicknameValidationResult
 import com.egobook.app.domain.model.account.NicknameValidator
+import com.egobook.app.domain.model.account.WithdrawReasonType
 import com.egobook.app.domain.repository.account.AccountRepository
 import com.egobook.app.ui.home.repository.UserRepository
 import com.egobook.app.util.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 import com.egobook.app.domain.model.auth.AuthError
 
@@ -38,6 +43,27 @@ class AccountViewModel @Inject constructor(
 
     private val _deleteAccountState = MutableStateFlow<UiState<Unit>>(UiState.Idle)
     val deleteAccountState = _deleteAccountState.asStateFlow()
+
+    private val _selectedWithdrawReason = MutableStateFlow<WithdrawReasonType?>(null)
+    val selectedWithdrawReason = _selectedWithdrawReason.asStateFlow()
+
+    private val _withdrawReasonText = MutableStateFlow("")
+    val withdrawReasonText = _withdrawReasonText.asStateFlow()
+
+    private val _withdrawToastEvent = MutableSharedFlow<String>(replay = 0)
+    val withdrawToastEvent = _withdrawToastEvent.asSharedFlow()
+
+    /** 사유를 골랐고, 기타인 경우 상세 사유까지 입력했는지 */
+    val isWithdrawReasonValid = combine(
+        _selectedWithdrawReason,
+        _withdrawReasonText
+    ) { reason, text ->
+        when (reason) {
+            null -> false
+            WithdrawReasonType.OTHER -> text.isNotBlank()
+            else -> true
+        }
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
 
     private val _nickname = MutableStateFlow<String?>(null)
     val nickname = _nickname.asStateFlow()
@@ -157,21 +183,69 @@ class AccountViewModel @Inject constructor(
         _nicknameUpdateState.value = UiState.Idle
     }
 
+    fun selectWithdrawReason(reason: WithdrawReasonType) {
+        _selectedWithdrawReason.value = reason
+        // 기타 외의 사유로 바꾸면 입력해 둔 상세 사유는 버린다
+        if (reason != WithdrawReasonType.OTHER) {
+            _withdrawReasonText.value = ""
+        }
+    }
+
+    fun updateWithdrawReasonText(text: String) {
+        _withdrawReasonText.value = text.take(WithdrawReasonType.MAX_TEXT_LENGTH)
+    }
+
+    fun resetWithdrawReason() {
+        _selectedWithdrawReason.value = null
+        _withdrawReasonText.value = ""
+        _deleteAccountState.value = UiState.Idle
+    }
+
+    /**
+     * 선택한 사유를 저장한 뒤 회원 탈퇴를 진행한다.
+     *
+     * 탈퇴 API를 먼저 호출하면 사유가 저장되지 않으므로 순서를 바꾸면 안 된다.
+     * 사유 저장 실패는 탈퇴 자체를 막지 않는다.
+     */
     fun deleteAccount() {
+        val reason = _selectedWithdrawReason.value
+        if (reason == null || !isWithdrawReasonValid.value) {
+            viewModelScope.launch {
+                _withdrawToastEvent.emit(
+                    if (reason == WithdrawReasonType.OTHER) "탈퇴 사유를 작성해 주세요"
+                    else "탈퇴 이유를 선택해 주세요"
+                )
+            }
+            return
+        }
+
         viewModelScope.launch {
             _deleteAccountState.value = UiState.Loading
             analyticsLogger.logEvent(AnalyticsEvent.ACCOUNT_WITHDRAW_REQUEST)
 
+            accountRepository.submitWithdrawReason(reason, _withdrawReasonText.value)
+                .onFailure { e ->
+                    Timber.w(e, "탈퇴 사유 저장 실패, 탈퇴는 계속 진행합니다")
+                }
+
             accountRepository.deleteAccount()
                 .onSuccess {
                     _deleteAccountState.value = UiState.Success(Unit)
-                    analyticsLogger.logEvent(AnalyticsEvent.ACCOUNT_WITHDRAW_CONFIRM)
+                    analyticsLogger.logEvent(
+                        AnalyticsEvent.ACCOUNT_WITHDRAW_CONFIRM,
+                        mapOf(ANALYTICS_PARAM_REASON_TYPE to reason.value)
+                    )
                 }
                 .onFailure { e ->
-                    _deleteAccountState.value =
-                        UiState.Failure(e.message ?: "회원 탈퇴에 실패했습니다")
+                    val message = e.message ?: "회원 탈퇴에 실패했습니다"
+                    _deleteAccountState.value = UiState.Failure(message)
+                    _withdrawToastEvent.emit(message)
                 }
         }
+    }
+
+    companion object {
+        private const val ANALYTICS_PARAM_REASON_TYPE = "reason_type"
     }
 
 }

--- a/app/src/main/res/drawable/bg_withdraw_reason_input.xml
+++ b/app/src/main/res/drawable/bg_withdraw_reason_input.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/layer_white" />
+    <stroke
+        android:width="1dp"
+        android:color="@color/letter_bg_green" />
+    <corners android:radius="4dp" />
+</shape>

--- a/app/src/main/res/drawable/bg_withdraw_reason_item.xml
+++ b/app/src/main/res/drawable/bg_withdraw_reason_item.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_selected="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/green_secondary" />
+            <corners android:radius="4dp" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/transparent" />
+            <corners android:radius="4dp" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/drawable/bg_withdraw_reason_other.xml
+++ b/app/src/main/res/drawable/bg_withdraw_reason_other.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/green_secondary" />
+    <corners android:radius="4dp" />
+</shape>

--- a/app/src/main/res/layout/fragment_account_delete_reason_dialog.xml
+++ b/app/src/main/res/layout/fragment_account_delete_reason_dialog.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/transparent"
+    android:gravity="center"
+    tools:context=".ui.account.view.AccountDeleteReasonDialogFragment">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/dialog_background"
+        android:orientation="vertical"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:fontFamily="@font/arita_semibold"
+            android:gravity="center"
+            android:lineHeight="24dp"
+            android:text="탈퇴 이유를 알려주세요"
+            android:textColor="@color/neutral"
+            android:textSize="16dp" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:fontFamily="@font/arita_medium"
+            android:gravity="center"
+            android:lineHeight="18sp"
+            android:text="소중한 의견을 반영해\n더 좋은 에고북을 만들겠습니다"
+            android:textColor="@color/neutral"
+            android:textSize="12dp" />
+
+        <TextView
+            android:id="@+id/tv_reason_not_used_often"
+            style="@style/WithdrawReasonItemStyle"
+            android:layout_marginTop="20dp"
+            android:text="자주 사용하지 않아요" />
+
+        <View style="@style/WithdrawReasonDividerStyle" />
+
+        <TextView
+            android:id="@+id/tv_reason_lack_of_content"
+            style="@style/WithdrawReasonItemStyle"
+            android:text="콘텐츠나 기능이 부족해요" />
+
+        <View style="@style/WithdrawReasonDividerStyle" />
+
+        <TextView
+            android:id="@+id/tv_reason_inconvenient_ui"
+            style="@style/WithdrawReasonItemStyle"
+            android:text="앱 사용이 불편해요" />
+
+        <View style="@style/WithdrawReasonDividerStyle" />
+
+        <TextView
+            android:id="@+id/tv_reason_difficult_to_collect_ink"
+            style="@style/WithdrawReasonItemStyle"
+            android:text="잉크를 모으기 어려워요" />
+
+        <View
+            android:id="@+id/divider_other"
+            style="@style/WithdrawReasonDividerStyle" />
+
+        <TextView
+            android:id="@+id/tv_reason_other"
+            style="@style/WithdrawReasonItemStyle"
+            android:text="기타 (직접 작성)" />
+
+        <!-- 기타 선택 시에만 노출되는 상세 사유 입력 영역 -->
+        <LinearLayout
+            android:id="@+id/layout_other_input"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@drawable/bg_withdraw_reason_other"
+            android:orientation="vertical"
+            android:paddingStart="12dp"
+            android:paddingTop="12dp"
+            android:paddingEnd="12dp"
+            android:paddingBottom="12dp"
+            android:visibility="gone"
+            tools:visibility="visible">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:fontFamily="@font/arita_semibold"
+                android:gravity="center"
+                android:text="탈퇴 사유를 작성해 주세요"
+                android:textColor="@color/neutral"
+                android:textSize="14dp" />
+
+            <EditText
+                android:id="@+id/et_other_reason"
+                android:layout_width="match_parent"
+                android:layout_height="88dp"
+                android:layout_marginTop="10dp"
+                android:background="@drawable/bg_withdraw_reason_input"
+                android:fontFamily="@font/arita_medium"
+                android:gravity="top|start"
+                android:hint="탈퇴 사유를 작성해 주세요"
+                android:importantForAutofill="no"
+                android:inputType="textMultiLine"
+                android:maxLength="500"
+                android:padding="10dp"
+                android:textColor="@color/neutral"
+                android:textColorHint="@color/neutral_subtle"
+                android:textSize="12dp" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="24dp"
+            android:orientation="horizontal">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btn_back"
+                style="@style/DeleteButtonStyle"
+                android:layout_width="94.5dp"
+                android:layout_height="42dp"
+                android:layout_marginEnd="12dp"
+                android:insetTop="0dp"
+                android:insetBottom="0dp"
+                android:text="돌아가기" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btn_real_delete"
+                style="@style/RedButtonStyle"
+                android:layout_width="94.5dp"
+                android:layout_height="42dp"
+                android:insetTop="0dp"
+                android:insetBottom="0dp"
+                android:text="탈퇴하기"
+                android:textSize="12dp" />
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+</FrameLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -177,6 +177,27 @@
 
     </style>
 
+    <!-- 회원탈퇴 사유 선택 항목 -->
+    <style name="WithdrawReasonItemStyle">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:background">@drawable/bg_withdraw_reason_item</item>
+        <item name="android:paddingTop">12dp</item>
+        <item name="android:paddingBottom">12dp</item>
+        <item name="android:gravity">center</item>
+        <item name="android:fontFamily">@font/arita_semibold</item>
+        <item name="android:textColor">@color/neutral</item>
+        <item name="android:textSize">14dp</item>
+        <item name="android:letterSpacing">-0.03</item>
+    </style>
+
+    <!-- 회원탈퇴 사유 항목 구분선 -->
+    <style name="WithdrawReasonDividerStyle">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">1dp</item>
+        <item name="android:background">@color/neutral_stroke</item>
+    </style>
+
     <!-- 날짜 입력 EditText 스타일 -->
     <style name="DatePickerEditTextStyle" parent="Widget.AppCompat.EditText">
         <item name="android:layout_height">wrap_content</item>


### PR DESCRIPTION
## 📝 작업 내용
회원탈퇴 플로우에 탈퇴 사유 선택 단계를 추가했습니다.

**변경 플로우**: `탈퇴 확인` → **`탈퇴 이유 선택`** → `POST /users/withdraw/reason` → `DELETE /users/withdraw` → `완료`

### UI
- `AccountDeleteReasonDialogFragment` 및 `fragment_account_delete_reason_dialog.xml` 추가
  - 사유 단일 선택 / 선택 항목 배경 하이라이트 (`WithdrawReasonItemStyle`, `bg_withdraw_reason_item`)
  - `기타 (직접 작성)` 선택 시 해당 자리에 상세 사유 입력 영역 노출 (최대 500자)
  - `탈퇴하기` 활성화 조건: 사유 1개 선택 (기타인 경우 텍스트 입력 필수)
- `AccountDeleteDialog1Fragment`: `탈퇴하기` 클릭 시 바로 탈퇴 API를 호출하지 않고 사유 선택 다이얼로그로 이동

### 데이터 / 도메인
- `WithdrawReasonType` enum 및 `WithdrawReasonRequest` DTO 신설
- `AccountApiService.submitWithdrawReason()` 추가 (`POST /users/withdraw/reason`)
- `AccountRepository` / `AccountRepositoryImpl` 에 `submitWithdrawReason(reasonType, text)` 추가
- `AccountViewModel` 에 선택 사유 상태 · 유효성 검증 · 토스트 이벤트 추가

### 기타
- Analytics: `ACCOUNT_WITHDRAW_CONFIRM` 이벤트에 `reason_type` 파라미터 추가
- 탈퇴 실패 시 토스트 노출 (기존 `observeDeleteAccountState()` 의 TODO 처리)
- 탈퇴 완료 다이얼로그가 사용자가 화면을 터치해야만 로그인 화면으로 넘어가던 문제 수정 (2초 뒤 자동 이동)

## 🔗 관련 이슈
- Close #126

## 📸 스크린샷
| 탈퇴 사유 선택 | 기타 선택 시 |
| --- | --- |
| (첨부 예정) | (첨부 예정) |

## 💬 요구사항(선택)
- **API 스펙 확인 필요**: 사유 전달을 `DELETE /users/withdraw` 의 body가 아니라 별도 엔드포인트(`POST /users/withdraw/reason`)로 분리했습니다. 서버 정책상 탈퇴 API보다 **먼저** 호출해야 저장되며, 사유 저장이 실패해도 탈퇴 자체는 계속 진행하도록 했습니다. 이 방식이 맞는지 확인 부탁드립니다.
- **사유 코드 값**: `NOT_USED_OFTEN` / `LACK_OF_CONTENT` / `INCONVENIENT_UI` / `DIFFICULT_TO_COLLECT_INK` / `OTHER` 로 정의했습니다.
- **디자인 확인**: `btn_real_delete` 가 쓰는 `RedButtonStyle` 에 `state_enabled="false"` 처리가 없어, 사유 미선택 상태에서도 버튼이 빨간색 그대로 보입니다. 비활성 색상을 추가할지 의견 주세요.

## ✅ 체크리스트
- [x] 관련 없는 변경사항 삭제 했는가? (불필요한 주석, 로그 등)
- [ ] 테스트 여부 (Unit Test 등) — 별도 Unit Test는 추가하지 않았고 기기에서 플로우 확인만 했습니다
