### PR TITLE
[🐛Fix] 탈퇴 사유 다이얼로그 하단 버튼 균등 분할

### DIFF
--- a/app/src/main/res/layout/fragment_account_delete_reason_dialog.xml
+++ b/app/src/main/res/layout/fragment_account_delete_reason_dialog.xml
@@ -115,20 +115,22 @@
 
         </LinearLayout>
 
+        <!-- 다이얼로그 폭이 화면에 맞춰 늘어나므로 두 버튼을 균등 분할한다 -->
         <LinearLayout
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
             android:layout_marginTop="16dp"
             android:layout_marginBottom="24dp"
+            android:baselineAligned="false"
             android:orientation="horizontal">
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/btn_back"
                 style="@style/DeleteButtonStyle"
-                android:layout_width="94.5dp"
+                android:layout_width="0dp"
                 android:layout_height="42dp"
-                android:layout_marginEnd="12dp"
+                android:layout_marginEnd="6dp"
+                android:layout_weight="1"
                 android:insetTop="0dp"
                 android:insetBottom="0dp"
                 android:text="돌아가기" />
@@ -136,8 +138,10 @@
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/btn_real_delete"
                 style="@style/RedButtonStyle"
-                android:layout_width="94.5dp"
+                android:layout_width="0dp"
                 android:layout_height="42dp"
+                android:layout_marginStart="6dp"
+                android:layout_weight="1"
                 android:insetTop="0dp"
                 android:insetBottom="0dp"
                 android:text="탈퇴하기"


### PR DESCRIPTION
## 📝 작업 내용
탈퇴 이유 선택 다이얼로그 하단 `돌아가기` / `탈퇴하기` 버튼을 좌우 균등 분할로 변경했습니다.

다이얼로그 창 폭을 화면 폭(좌우 24dp 마진)에 맞춰 넓힌 뒤, 버튼이 `94.5dp` 고정 폭이라 가운데에만 몰려 보이는 문제가 있었습니다.

| | 이전 | 이후 |
| --- | --- | --- |
| 컨테이너 | `wrap_content` + `center_horizontal` | `match_parent` |
| 각 버튼 | `94.5dp` 고정 | `0dp` + `layout_weight="1"` |
| 간격 | `marginEnd 12dp` | 좌우 `6dp` 씩 (합 12dp 유지) |

가운데 간격은 12dp 그대로이고, 다이얼로그 좌우 패딩(16dp) 안쪽에서 두 버튼이 정확히 절반씩 차지합니다.

## 🔗 관련 이슈
- Fix #128

## 📸 스크린샷
- (첨부 예정)

## 💬 요구사항(선택)
- **base 브랜치가 `develop` 이 아니라 `feat/126/WithdrawReason` 입니다.** 수정 대상인 `fragment_account_delete_reason_dialog.xml` 이 아직 develop에 없어서 #127 위에 쌓았습니다. #127 이 먼저 머지된 뒤 이 PR을 머지해 주세요.

## ✅ 체크리스트
- [x] 관련 없는 변경사항 삭제 했는가? (불필요한 주석, 로그 등)
- [x] 빌드 확인 (`./gradlew assembleDebug`)
