### PR TITLE
🐛Fix - 고북이 프로필 & 레벨 하드코딩 수정

### DIFF
--- a/app/src/main/java/com/egobook/app/data/model/square/friend/FriendListResponse.kt
+++ b/app/src/main/java/com/egobook/app/data/model/square/friend/FriendListResponse.kt
@@ -15,7 +15,11 @@ data class FriendResponse(
     @SerializedName("nickname")
     val name: String,
     @SerializedName("level")
-    val level: Long
+    val level: Long,
+    @SerializedName("turtleImageUrl")
+    val turtleImageUrl: String? = null,
+    @SerializedName("backgroundImageUrl")
+    val backgroundImageUrl: String? = null
 )
 
 fun FriendListResponse.toDomain(): FriendList = FriendList(
@@ -26,6 +30,8 @@ fun FriendListResponse.toDomain(): FriendList = FriendList(
 fun FriendResponse.toDomain(): Friend = Friend(
     id = id,
     name = name,
-    level = level
+    level = level,
+    turtleImageUrl = turtleImageUrl,
+    backgroundImageUrl = backgroundImageUrl
 )
 

--- a/app/src/main/java/com/egobook/app/data/model/square/friend/FriendRequestResponse.kt
+++ b/app/src/main/java/com/egobook/app/data/model/square/friend/FriendRequestResponse.kt
@@ -12,6 +12,10 @@ data class FriendRequestResponse(
     val nickname: String,
     @SerializedName("level")
     val level: Long,
+    @SerializedName("turtleImageUrl")
+    val turtleImageUrl: String? = null,
+    @SerializedName("backgroundImageUrl")
+    val backgroundImageUrl: String? = null,
     @SerializedName("requestedAt")
     val requestedAt: String
 )
@@ -21,5 +25,7 @@ fun FriendRequestResponse.toDomain(): FriendRequest = FriendRequest(
     userId = userId,
     nickname = nickname,
     level = level,
+    turtleImageUrl = turtleImageUrl,
+    backgroundImageUrl = backgroundImageUrl,
     requestedAt = requestedAt
 )

--- a/app/src/main/java/com/egobook/app/data/model/square/friend/SearchUserResponse.kt
+++ b/app/src/main/java/com/egobook/app/data/model/square/friend/SearchUserResponse.kt
@@ -10,13 +10,16 @@ data class SearchUserResponse(
     val nickname: String,
     @SerializedName("level")
     val level: Long,
-    @SerializedName("profileImageUrl")
-    val profileImageUrl: String? = null
+    @SerializedName("turtleImageUrl")
+    val turtleImageUrl: String? = null,
+    @SerializedName("backgroundImageUrl")
+    val backgroundImageUrl: String? = null
 )
 
 fun SearchUserResponse.toDomain(): SearchUser = SearchUser(
     userId = userId,
     nickname = nickname,
     level = level,
-    profileImageUrl = profileImageUrl
+    turtleImageUrl = turtleImageUrl,
+    backgroundImageUrl = backgroundImageUrl
 )

--- a/app/src/main/java/com/egobook/app/data/model/square/question/UserTodayQuestionAnswerResponse.kt
+++ b/app/src/main/java/com/egobook/app/data/model/square/question/UserTodayQuestionAnswerResponse.kt
@@ -26,6 +26,8 @@ data class UserTodayQuestionAnswerItemResponse(
     val content: String,
     @SerializedName("createdAt")
     val createdAt: String,
+    @SerializedName("level")
+    val level: Long,
     @SerializedName("turtleImageUrl")
     val turtleImageUrl: String? = null,
     @SerializedName("backgroundImageUrl")
@@ -47,6 +49,7 @@ fun UserTodayQuestionAnswerItemResponse.toDomain(): UserTodayQuestionAnswerItem 
         nickname = nickname,
         content = content,
         createdAt = createdAt,
+        level = level,
         turtleImageUrl = turtleImageUrl,
         backgroundImageUrl = backgroundImageUrl
     )

--- a/app/src/main/java/com/egobook/app/data/model/square/question/UserTodayQuestionAnswerResponse.kt
+++ b/app/src/main/java/com/egobook/app/data/model/square/question/UserTodayQuestionAnswerResponse.kt
@@ -25,7 +25,11 @@ data class UserTodayQuestionAnswerItemResponse(
     @SerializedName("content")
     val content: String,
     @SerializedName("createdAt")
-    val createdAt: String
+    val createdAt: String,
+    @SerializedName("turtleImageUrl")
+    val turtleImageUrl: String? = null,
+    @SerializedName("backgroundImageUrl")
+    val backgroundImageUrl: String? = null
 )
 
 fun UserTodayQuestionAnswerResponse.toDomain(): UserTodayQuestionAnswer =
@@ -42,5 +46,7 @@ fun UserTodayQuestionAnswerItemResponse.toDomain(): UserTodayQuestionAnswerItem 
         userId = userId,
         nickname = nickname,
         content = content,
-        createdAt = createdAt
+        createdAt = createdAt,
+        turtleImageUrl = turtleImageUrl,
+        backgroundImageUrl = backgroundImageUrl
     )

--- a/app/src/main/java/com/egobook/app/data/model/square/question/UserTodayQuestionAnswerResponse.kt
+++ b/app/src/main/java/com/egobook/app/data/model/square/question/UserTodayQuestionAnswerResponse.kt
@@ -28,6 +28,8 @@ data class UserTodayQuestionAnswerItemResponse(
     val createdAt: String,
     @SerializedName("level")
     val level: Long,
+    @SerializedName("topAbilityName")
+    val topAbilityName: String? = null,
     @SerializedName("turtleImageUrl")
     val turtleImageUrl: String? = null,
     @SerializedName("backgroundImageUrl")
@@ -50,6 +52,7 @@ fun UserTodayQuestionAnswerItemResponse.toDomain(): UserTodayQuestionAnswerItem 
         content = content,
         createdAt = createdAt,
         level = level,
+        topAbilityName = topAbilityName,
         turtleImageUrl = turtleImageUrl,
         backgroundImageUrl = backgroundImageUrl
     )

--- a/app/src/main/java/com/egobook/app/domain/model/FriendList.kt
+++ b/app/src/main/java/com/egobook/app/domain/model/FriendList.kt
@@ -8,5 +8,7 @@ data class FriendList(
 data class Friend(
     val id: Long,
     val name: String,
-    val level: Long
+    val level: Long,
+    val turtleImageUrl: String? = null,
+    val backgroundImageUrl: String? = null
 )

--- a/app/src/main/java/com/egobook/app/domain/model/FriendRequest.kt
+++ b/app/src/main/java/com/egobook/app/domain/model/FriendRequest.kt
@@ -5,5 +5,7 @@ data class FriendRequest(
     val userId: Long,
     val nickname: String,
     val level: Long,
+    val turtleImageUrl: String? = null,
+    val backgroundImageUrl: String? = null,
     val requestedAt: String
 )

--- a/app/src/main/java/com/egobook/app/domain/model/SearchUser.kt
+++ b/app/src/main/java/com/egobook/app/domain/model/SearchUser.kt
@@ -4,5 +4,6 @@ data class SearchUser(
     val userId: Long,
     val nickname: String,
     val level: Long,
-    val profileImageUrl: String? = null
+    val turtleImageUrl: String? = null,
+    val backgroundImageUrl: String? = null
 )

--- a/app/src/main/java/com/egobook/app/domain/model/square/question/UserTodayQuestionAnswer.kt
+++ b/app/src/main/java/com/egobook/app/domain/model/square/question/UserTodayQuestionAnswer.kt
@@ -12,5 +12,7 @@ data class UserTodayQuestionAnswerItem(
     val userId: Long,
     val nickname: String,
     val content: String,
-    val createdAt: String
+    val createdAt: String,
+    val turtleImageUrl: String? = null,
+    val backgroundImageUrl: String? = null
 )

--- a/app/src/main/java/com/egobook/app/domain/model/square/question/UserTodayQuestionAnswer.kt
+++ b/app/src/main/java/com/egobook/app/domain/model/square/question/UserTodayQuestionAnswer.kt
@@ -13,6 +13,7 @@ data class UserTodayQuestionAnswerItem(
     val nickname: String,
     val content: String,
     val createdAt: String,
+    val level: Long,
     val turtleImageUrl: String? = null,
     val backgroundImageUrl: String? = null
 )

--- a/app/src/main/java/com/egobook/app/domain/model/square/question/UserTodayQuestionAnswer.kt
+++ b/app/src/main/java/com/egobook/app/domain/model/square/question/UserTodayQuestionAnswer.kt
@@ -14,6 +14,7 @@ data class UserTodayQuestionAnswerItem(
     val content: String,
     val createdAt: String,
     val level: Long,
+    val topAbilityName: String? = null,
     val turtleImageUrl: String? = null,
     val backgroundImageUrl: String? = null
 )

--- a/app/src/main/java/com/egobook/app/store/data/ShopRepository.kt
+++ b/app/src/main/java/com/egobook/app/store/data/ShopRepository.kt
@@ -58,7 +58,9 @@ class ShopRepository @Inject constructor(
     }
 
     suspend fun equipItemPermanently(item: CustomItem, isEquipped: Boolean): List<CustomItem> {
-        remoteShopDataSource.permanentEquipItem(item, isEquipped)
+        val result = remoteShopDataSource.permanentEquipItem(item, isEquipped)
+        check(result.isSuccess) { "Failed to update equipped item" }
+        remoteShopDataSource.confirmProfile()
         return remoteShopDataSource.loadEquippedItems()
     }
 

--- a/app/src/main/java/com/egobook/app/store/data/network/RemoteShopDataSource.kt
+++ b/app/src/main/java/com/egobook/app/store/data/network/RemoteShopDataSource.kt
@@ -75,6 +75,10 @@ class RemoteShopDataSource @Inject constructor(
             return EquipState(isSuccess = false)
         }
     }
+
+    suspend fun confirmProfile() {
+        apiService.confirmProfile()
+    }
 }
 
 fun ItemType.ofName(): String =

--- a/app/src/main/java/com/egobook/app/store/data/network/RemoteShopDataSource.kt
+++ b/app/src/main/java/com/egobook/app/store/data/network/RemoteShopDataSource.kt
@@ -10,6 +10,7 @@ import com.egobook.app.store.data.model.ItemType
 import com.egobook.app.store.data.network.dto.ShopItemDto
 import com.egobook.app.store.ui.CustomItem
 import retrofit2.Retrofit
+import kotlinx.coroutines.CancellationException
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -71,6 +72,8 @@ class RemoteShopDataSource @Inject constructor(
                 PermanentEquipRequest(itemId = item.id.toInt(), isEquipped = isEquipped)
             )
             return EquipState(isSuccess = true)
+        } catch (err: CancellationException) {
+            throw err
         } catch (err: Exception) {
             return EquipState(isSuccess = false)
         }

--- a/app/src/main/java/com/egobook/app/store/data/network/ShopApiService.kt
+++ b/app/src/main/java/com/egobook/app/store/data/network/ShopApiService.kt
@@ -27,4 +27,12 @@ interface ShopApiService {
 
     @PATCH("/shop/equip")
     suspend fun equipItemPermanently(@Body request: PermanentEquipRequest): BaseResponse<EquippedItemDto>
+
+    @POST("/shop/profile/confirm")
+    suspend fun confirmProfile(): BaseResponse<ProfileImageDto>
 }
+
+data class ProfileImageDto(
+    val turtleImageUrl: String?,
+    val backgroundImageUrl: String?
+)

--- a/app/src/main/java/com/egobook/app/ui/square/LevelBadgeMapper.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/LevelBadgeMapper.kt
@@ -1,0 +1,21 @@
+package com.egobook.app.ui.square
+
+import androidx.annotation.DrawableRes
+import com.egobook.app.R
+import com.egobook.app.ui.home.user.Level
+import com.egobook.app.ui.home.user.LevelType
+
+@DrawableRes
+fun levelBadgeDrawable(level: Long): Int {
+    require(level in Level.MINIMUM_LEVEL.toLong()..Level.MAXIMUM_LEVEL.toLong())
+    return when (LevelType.of(level.toInt())) {
+        LevelType.ONE -> R.drawable.level_type_1
+        LevelType.TWO -> R.drawable.level_type_2
+        LevelType.THREE -> R.drawable.level_type_3
+        LevelType.FOUR -> R.drawable.level_type_4
+        LevelType.FIVE -> R.drawable.level_type_5
+        LevelType.SIX -> R.drawable.level_type_6
+        LevelType.SEVEN -> R.drawable.level_type_7
+        LevelType.EIGHT -> R.drawable.level_type_8
+    }
+}

--- a/app/src/main/java/com/egobook/app/ui/square/ProfileImagePlacement.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/ProfileImagePlacement.kt
@@ -16,7 +16,7 @@ enum class ProfileImagePlacement(
 ) {
     PLAZA_TURTLE(ProfileScaleMode.HEAD_CENTERED, targetHeadWidthFraction = 0.65f),
     PLAZA_BACKGROUND(ProfileScaleMode.CENTER_CROP),
-    FRIEND_TURTLE(ProfileScaleMode.HEAD_CENTERED, targetHeadWidthFraction = 0.85f),
+    FRIEND_TURTLE(ProfileScaleMode.HEAD_CENTERED, targetHeadWidthFraction = 0.70f),
     FRIEND_BACKGROUND(ProfileScaleMode.CENTER_CROP, verticalOffsetFraction = -0.131f)
 }
 

--- a/app/src/main/java/com/egobook/app/ui/square/ProfileImagePlacement.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/ProfileImagePlacement.kt
@@ -1,21 +1,23 @@
 package com.egobook.app.ui.square
 
-enum class ProfileAlignment {
-    START,
-    CENTER,
-    END
+const val TURTLE_HEAD_CENTER_X_FRACTION = 0.19f
+const val TURTLE_HEAD_CENTER_Y_FRACTION = 0.66f
+const val TURTLE_HEAD_WIDTH_FRACTION = 0.30f
+
+enum class ProfileScaleMode {
+    HEAD_CENTERED,
+    CENTER_CROP
 }
 
 enum class ProfileImagePlacement(
-    val scale: Float,
-    val horizontal: ProfileAlignment,
-    val vertical: ProfileAlignment,
+    val scaleMode: ProfileScaleMode,
+    val targetHeadWidthFraction: Float = 0f,
     val verticalOffsetFraction: Float = 0f
 ) {
-    PLAZA_TURTLE(0.3f, ProfileAlignment.START, ProfileAlignment.END),
-    PLAZA_BACKGROUND(0.1f, ProfileAlignment.CENTER, ProfileAlignment.CENTER),
-    FRIEND_TURTLE(1f, ProfileAlignment.START, ProfileAlignment.END),
-    FRIEND_BACKGROUND(0.5f, ProfileAlignment.CENTER, ProfileAlignment.CENTER, -0.131f)
+    PLAZA_TURTLE(ProfileScaleMode.HEAD_CENTERED, targetHeadWidthFraction = 0.65f),
+    PLAZA_BACKGROUND(ProfileScaleMode.CENTER_CROP),
+    FRIEND_TURTLE(ProfileScaleMode.HEAD_CENTERED, targetHeadWidthFraction = 0.85f),
+    FRIEND_BACKGROUND(ProfileScaleMode.CENTER_CROP, verticalOffsetFraction = -0.131f)
 }
 
 data class ProfileImageTransform(
@@ -34,20 +36,28 @@ fun calculateProfileImageTransform(
     require(frameWidth > 0 && frameHeight > 0)
     require(imageWidth > 0 && imageHeight > 0)
 
-    val scale = placement.scale
-    val scaledWidth = imageWidth * scale
-    val scaledHeight = imageHeight * scale
-    return ProfileImageTransform(
-        scale = scale,
-        translateX = alignedOffset(frameWidth.toFloat(), scaledWidth, placement.horizontal),
-        translateY = alignedOffset(frameHeight.toFloat(), scaledHeight, placement.vertical) +
-            frameHeight * placement.verticalOffsetFraction
-    )
-}
+    return when (placement.scaleMode) {
+        ProfileScaleMode.HEAD_CENTERED -> {
+            val scale = frameWidth * placement.targetHeadWidthFraction /
+                (imageWidth * TURTLE_HEAD_WIDTH_FRACTION)
+            ProfileImageTransform(
+                scale = scale,
+                translateX = frameWidth / 2f - imageWidth * TURTLE_HEAD_CENTER_X_FRACTION * scale,
+                translateY = frameHeight / 2f - imageHeight * TURTLE_HEAD_CENTER_Y_FRACTION * scale
+            )
+        }
 
-private fun alignedOffset(container: Float, content: Float, alignment: ProfileAlignment): Float =
-    when (alignment) {
-        ProfileAlignment.START -> 0f
-        ProfileAlignment.CENTER -> (container - content) / 2f
-        ProfileAlignment.END -> container - content
+        ProfileScaleMode.CENTER_CROP -> {
+            val scale = maxOf(
+                frameWidth.toFloat() / imageWidth,
+                frameHeight.toFloat() / imageHeight
+            )
+            ProfileImageTransform(
+                scale = scale,
+                translateX = (frameWidth - imageWidth * scale) / 2f,
+                translateY = (frameHeight - imageHeight * scale) / 2f +
+                    frameHeight * placement.verticalOffsetFraction
+            )
+        }
     }
+}

--- a/app/src/main/java/com/egobook/app/ui/square/ProfileImagePlacement.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/ProfileImagePlacement.kt
@@ -34,11 +34,7 @@ fun calculateProfileImageTransform(
     require(frameWidth > 0 && frameHeight > 0)
     require(imageWidth > 0 && imageHeight > 0)
 
-    val fitScale = minOf(
-        frameWidth.toFloat() / imageWidth,
-        frameHeight.toFloat() / imageHeight
-    )
-    val scale = fitScale * placement.scale
+    val scale = placement.scale
     val scaledWidth = imageWidth * scale
     val scaledHeight = imageHeight * scale
     return ProfileImageTransform(

--- a/app/src/main/java/com/egobook/app/ui/square/ProfileImagePlacement.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/ProfileImagePlacement.kt
@@ -12,11 +12,18 @@ enum class ProfileScaleMode {
 enum class ProfileImagePlacement(
     val scaleMode: ProfileScaleMode,
     val targetHeadWidthFraction: Float = 0f,
+    val targetCenterXFraction: Float = 0.5f,
+    val targetCenterYFraction: Float = 0.5f,
     val verticalOffsetFraction: Float = 0f
 ) {
     PLAZA_TURTLE(ProfileScaleMode.HEAD_CENTERED, targetHeadWidthFraction = 0.65f),
     PLAZA_BACKGROUND(ProfileScaleMode.CENTER_CROP),
-    FRIEND_TURTLE(ProfileScaleMode.HEAD_CENTERED, targetHeadWidthFraction = 0.70f),
+    FRIEND_TURTLE(
+        ProfileScaleMode.HEAD_CENTERED,
+        targetHeadWidthFraction = 0.60f,
+        targetCenterXFraction = 0.38f,
+        targetCenterYFraction = 0.62f
+    ),
     FRIEND_BACKGROUND(ProfileScaleMode.CENTER_CROP, verticalOffsetFraction = -0.131f)
 }
 
@@ -42,8 +49,10 @@ fun calculateProfileImageTransform(
                 (imageWidth * TURTLE_HEAD_WIDTH_FRACTION)
             ProfileImageTransform(
                 scale = scale,
-                translateX = frameWidth / 2f - imageWidth * TURTLE_HEAD_CENTER_X_FRACTION * scale,
-                translateY = frameHeight / 2f - imageHeight * TURTLE_HEAD_CENTER_Y_FRACTION * scale
+                translateX = frameWidth * placement.targetCenterXFraction -
+                    imageWidth * TURTLE_HEAD_CENTER_X_FRACTION * scale,
+                translateY = frameHeight * placement.targetCenterYFraction -
+                    imageHeight * TURTLE_HEAD_CENTER_Y_FRACTION * scale
             )
         }
 

--- a/app/src/main/java/com/egobook/app/ui/square/ProfileImagePlacement.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/ProfileImagePlacement.kt
@@ -1,0 +1,57 @@
+package com.egobook.app.ui.square
+
+enum class ProfileAlignment {
+    START,
+    CENTER,
+    END
+}
+
+enum class ProfileImagePlacement(
+    val scale: Float,
+    val horizontal: ProfileAlignment,
+    val vertical: ProfileAlignment,
+    val verticalOffsetFraction: Float = 0f
+) {
+    PLAZA_TURTLE(0.3f, ProfileAlignment.START, ProfileAlignment.END),
+    PLAZA_BACKGROUND(0.1f, ProfileAlignment.CENTER, ProfileAlignment.CENTER),
+    FRIEND_TURTLE(1f, ProfileAlignment.START, ProfileAlignment.END),
+    FRIEND_BACKGROUND(0.5f, ProfileAlignment.CENTER, ProfileAlignment.CENTER, -0.131f)
+}
+
+data class ProfileImageTransform(
+    val scale: Float,
+    val translateX: Float,
+    val translateY: Float
+)
+
+fun calculateProfileImageTransform(
+    frameWidth: Int,
+    frameHeight: Int,
+    imageWidth: Int,
+    imageHeight: Int,
+    placement: ProfileImagePlacement
+): ProfileImageTransform {
+    require(frameWidth > 0 && frameHeight > 0)
+    require(imageWidth > 0 && imageHeight > 0)
+
+    val fitScale = minOf(
+        frameWidth.toFloat() / imageWidth,
+        frameHeight.toFloat() / imageHeight
+    )
+    val scale = fitScale * placement.scale
+    val scaledWidth = imageWidth * scale
+    val scaledHeight = imageHeight * scale
+    return ProfileImageTransform(
+        scale = scale,
+        translateX = alignedOffset(frameWidth.toFloat(), scaledWidth, placement.horizontal),
+        translateY = alignedOffset(frameHeight.toFloat(), scaledHeight, placement.vertical) +
+            frameHeight * placement.verticalOffsetFraction
+    )
+}
+
+private fun alignedOffset(container: Float, content: Float, alignment: ProfileAlignment): Float =
+    when (alignment) {
+        ProfileAlignment.START -> 0f
+        ProfileAlignment.CENTER -> (container - content) / 2f
+        ProfileAlignment.END -> container - content
+    }

--- a/app/src/main/java/com/egobook/app/ui/square/ProfileImageSourcePolicy.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/ProfileImageSourcePolicy.kt
@@ -1,3 +1,6 @@
 package com.egobook.app.ui.square
 
 fun hasRemoteProfileImage(url: String?): Boolean = !url.isNullOrBlank()
+
+fun profileTurtleScaleX(url: String?, isFallbackDisplayed: Boolean = false): Float =
+    if (hasRemoteProfileImage(url) && !isFallbackDisplayed) 1f else -1f

--- a/app/src/main/java/com/egobook/app/ui/square/ProfileImageSourcePolicy.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/ProfileImageSourcePolicy.kt
@@ -1,0 +1,3 @@
+package com.egobook.app.ui.square
+
+fun hasRemoteProfileImage(url: String?): Boolean = !url.isNullOrBlank()

--- a/app/src/main/java/com/egobook/app/ui/square/ProfileImageSourcePolicy.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/ProfileImageSourcePolicy.kt
@@ -2,5 +2,8 @@ package com.egobook.app.ui.square
 
 fun hasRemoteProfileImage(url: String?): Boolean = !url.isNullOrBlank()
 
-fun profileTurtleScaleX(url: String?, isFallbackDisplayed: Boolean = false): Float =
-    if (hasRemoteProfileImage(url) && !isFallbackDisplayed) 1f else -1f
+fun profileTurtleScaleX(
+    url: String?,
+    mirrorFallback: Boolean,
+    isFallbackDisplayed: Boolean = false
+): Float = if (mirrorFallback && (!hasRemoteProfileImage(url) || isFallbackDisplayed)) -1f else 1f

--- a/app/src/main/java/com/egobook/app/ui/square/TendencyIconMapper.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/TendencyIconMapper.kt
@@ -1,0 +1,15 @@
+package com.egobook.app.ui.square
+
+import androidx.annotation.DrawableRes
+import com.egobook.app.R
+import java.util.Locale
+
+@DrawableRes
+fun tendencyIconDrawable(topAbilityName: String?): Int = when (topAbilityName?.trim()?.uppercase(Locale.ROOT)) {
+    "공감성", "EMPATHY" -> R.drawable.ic_radar_heart
+    "자존감", "SELF_ESTEEM" -> R.drawable.ic_radar_diamond
+    "성실성", "DILIGENCE" -> R.drawable.ic_radar_clover
+    "긍정사고", "긍정적 사고", "POSITIVE_THINKING" -> R.drawable.ic_radar_sun
+    "감정조절", "EMOTION_REGULATION" -> R.drawable.ic_radar_star
+    else -> R.drawable.ic_square_friend_answer_star
+}

--- a/app/src/main/java/com/egobook/app/ui/square/TendencyIconMapper.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/TendencyIconMapper.kt
@@ -8,7 +8,7 @@ import java.util.Locale
 fun tendencyIconDrawable(topAbilityName: String?): Int = when (topAbilityName?.trim()?.uppercase(Locale.ROOT)) {
     "공감성", "EMPATHY" -> R.drawable.ic_radar_heart
     "자존감", "SELF_ESTEEM" -> R.drawable.ic_radar_diamond
-    "성실성", "DILIGENCE" -> R.drawable.ic_radar_clover
+    "성실성", "성실함", "DILIGENCE" -> R.drawable.ic_radar_clover
     "긍정사고", "긍정적 사고", "POSITIVE_THINKING" -> R.drawable.ic_radar_sun
     "감정조절", "EMOTION_REGULATION" -> R.drawable.ic_radar_star
     else -> R.drawable.ic_square_friend_answer_star

--- a/app/src/main/java/com/egobook/app/ui/square/adapter/FriendSearchAdapter.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/adapter/FriendSearchAdapter.kt
@@ -30,7 +30,7 @@ class FriendSearchAdapter(
             ivAddFriendSearchLevel.setImageResource(levelBadgeDrawable(item.level))
             tvAddFriendSearchNickname.text = item.nickname
             ivAddFriendSearchBackground.loadProfileBackground(item.backgroundImageUrl, ProfileImagePlacement.FRIEND_BACKGROUND)
-            ivAddFriendSearchImage.loadProfileTurtle(item.turtleImageUrl, R.drawable.default_turtle, ProfileImagePlacement.FRIEND_TURTLE)
+            ivAddFriendSearchImage.loadProfileTurtle(item.turtleImageUrl, R.drawable.default_turtle, ProfileImagePlacement.FRIEND_TURTLE, placeFallback = true)
             btnAddFriendSearchResultApply.setOnClickListener { onApply(item.userId, bindingAdapterPosition) }
         }
     }

--- a/app/src/main/java/com/egobook/app/ui/square/adapter/FriendSearchAdapter.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/adapter/FriendSearchAdapter.kt
@@ -9,6 +9,7 @@ import com.egobook.app.R
 import com.egobook.app.databinding.ItemSearchFriendBinding
 import com.egobook.app.ui.square.model.friend.SearchUserModel
 import com.egobook.app.ui.square.levelBadgeDrawable
+import com.egobook.app.ui.square.ProfileImagePlacement
 
 /**
  * 1. fallback(R.drawable.default_turtle) → null일 때 보여주는 기본 이미지 지정
@@ -28,8 +29,8 @@ class FriendSearchAdapter(
             tvAddFriendSearchLevel.text = "LV ${item.level}"
             ivAddFriendSearchLevel.setImageResource(levelBadgeDrawable(item.level))
             tvAddFriendSearchNickname.text = item.nickname
-            ivAddFriendSearchBackground.loadProfileBackground(item.backgroundImageUrl)
-            ivAddFriendSearchImage.loadProfileTurtle(item.turtleImageUrl, R.drawable.default_turtle)
+            ivAddFriendSearchBackground.loadProfileBackground(item.backgroundImageUrl, ProfileImagePlacement.FRIEND_BACKGROUND)
+            ivAddFriendSearchImage.loadProfileTurtle(item.turtleImageUrl, R.drawable.default_turtle, ProfileImagePlacement.FRIEND_TURTLE)
             btnAddFriendSearchResultApply.setOnClickListener { onApply(item.userId, bindingAdapterPosition) }
         }
     }

--- a/app/src/main/java/com/egobook/app/ui/square/adapter/FriendSearchAdapter.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/adapter/FriendSearchAdapter.kt
@@ -5,7 +5,6 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.bumptech.glide.Glide
 import com.egobook.app.R
 import com.egobook.app.databinding.ItemSearchFriendBinding
 import com.egobook.app.ui.square.model.friend.SearchUserModel
@@ -27,8 +26,8 @@ class FriendSearchAdapter(
             btnAddFriendSearchResultApply.text = "신청하기"
             tvAddFriendSearchLevel.text = "LV ${item.level}"
             tvAddFriendSearchNickname.text = item.nickname
-            Glide.with(ivAddFriendSearchImage).load(item.profileImageUrl)
-                .fallback(R.drawable.default_turtle).into(ivAddFriendSearchImage) // 1
+            ivAddFriendSearchBackground.loadProfileBackground(item.backgroundImageUrl)
+            ivAddFriendSearchImage.loadProfileTurtle(item.turtleImageUrl, R.drawable.default_turtle)
             btnAddFriendSearchResultApply.setOnClickListener { onApply(item.userId, bindingAdapterPosition) }
         }
     }

--- a/app/src/main/java/com/egobook/app/ui/square/adapter/FriendSearchAdapter.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/adapter/FriendSearchAdapter.kt
@@ -8,6 +8,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.egobook.app.R
 import com.egobook.app.databinding.ItemSearchFriendBinding
 import com.egobook.app.ui.square.model.friend.SearchUserModel
+import com.egobook.app.ui.square.levelBadgeDrawable
 
 /**
  * 1. fallback(R.drawable.default_turtle) → null일 때 보여주는 기본 이미지 지정
@@ -25,6 +26,7 @@ class FriendSearchAdapter(
             btnAddFriendSearchResultApply.alpha = 1f
             btnAddFriendSearchResultApply.text = "신청하기"
             tvAddFriendSearchLevel.text = "LV ${item.level}"
+            ivAddFriendSearchLevel.setImageResource(levelBadgeDrawable(item.level))
             tvAddFriendSearchNickname.text = item.nickname
             ivAddFriendSearchBackground.loadProfileBackground(item.backgroundImageUrl)
             ivAddFriendSearchImage.loadProfileTurtle(item.turtleImageUrl, R.drawable.default_turtle)

--- a/app/src/main/java/com/egobook/app/ui/square/adapter/FriendsListAdapter.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/adapter/FriendsListAdapter.kt
@@ -35,7 +35,7 @@ class FriendsListAdapter(private val onDeleted: (FriendModel) -> Unit): ListAdap
             tvItemFriendListLevel.text = "LV ${item.level}"
             ivItemFriendListLevel.setImageResource(levelBadgeDrawable(item.level))
             ivItemFriendListBackground.loadProfileBackground(item.backgroundImageUrl, ProfileImagePlacement.FRIEND_BACKGROUND)
-            ivItemFriendListImage.loadProfileTurtle(item.turtleImageUrl, R.drawable.default_turtle, ProfileImagePlacement.FRIEND_TURTLE)
+            ivItemFriendListImage.loadProfileTurtle(item.turtleImageUrl, R.drawable.default_turtle, ProfileImagePlacement.FRIEND_TURTLE, placeFallback = true)
             ivItemSquareFriendListDelete.setOnClickListener { onDeleted(item) }
         }
     }

--- a/app/src/main/java/com/egobook/app/ui/square/adapter/FriendsListAdapter.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/adapter/FriendsListAdapter.kt
@@ -5,6 +5,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.egobook.app.R
 import com.egobook.app.databinding.ItemSquareFriendListBinding
 import com.egobook.app.ui.square.model.friend.FriendListModel
 import com.egobook.app.ui.square.model.friend.FriendModel
@@ -30,6 +31,8 @@ class FriendsListAdapter(private val onDeleted: (FriendModel) -> Unit): ListAdap
         fun bind(item: FriendModel) = with(binding) {
             tvItemFriendListName.text = item.name
             tvItemFriendListLevel.text = "LV ${item.level}"
+            ivItemFriendListBackground.loadProfileBackground(item.backgroundImageUrl)
+            ivItemFriendListImage.loadProfileTurtle(item.turtleImageUrl, R.drawable.default_turtle)
             ivItemSquareFriendListDelete.setOnClickListener { onDeleted(item) }
         }
     }

--- a/app/src/main/java/com/egobook/app/ui/square/adapter/FriendsListAdapter.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/adapter/FriendsListAdapter.kt
@@ -9,6 +9,7 @@ import com.egobook.app.R
 import com.egobook.app.databinding.ItemSquareFriendListBinding
 import com.egobook.app.ui.square.model.friend.FriendListModel
 import com.egobook.app.ui.square.model.friend.FriendModel
+import com.egobook.app.ui.square.levelBadgeDrawable
 
 class FriendsListAdapter(private val onDeleted: (FriendModel) -> Unit): ListAdapter<FriendModel, FriendsListAdapter.FriendsListViewHolder>(diffUtil) {
 
@@ -31,6 +32,7 @@ class FriendsListAdapter(private val onDeleted: (FriendModel) -> Unit): ListAdap
         fun bind(item: FriendModel) = with(binding) {
             tvItemFriendListName.text = item.name
             tvItemFriendListLevel.text = "LV ${item.level}"
+            ivItemFriendListLevel.setImageResource(levelBadgeDrawable(item.level))
             ivItemFriendListBackground.loadProfileBackground(item.backgroundImageUrl)
             ivItemFriendListImage.loadProfileTurtle(item.turtleImageUrl, R.drawable.default_turtle)
             ivItemSquareFriendListDelete.setOnClickListener { onDeleted(item) }

--- a/app/src/main/java/com/egobook/app/ui/square/adapter/FriendsListAdapter.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/adapter/FriendsListAdapter.kt
@@ -10,6 +10,7 @@ import com.egobook.app.databinding.ItemSquareFriendListBinding
 import com.egobook.app.ui.square.model.friend.FriendListModel
 import com.egobook.app.ui.square.model.friend.FriendModel
 import com.egobook.app.ui.square.levelBadgeDrawable
+import com.egobook.app.ui.square.ProfileImagePlacement
 
 class FriendsListAdapter(private val onDeleted: (FriendModel) -> Unit): ListAdapter<FriendModel, FriendsListAdapter.FriendsListViewHolder>(diffUtil) {
 
@@ -33,8 +34,8 @@ class FriendsListAdapter(private val onDeleted: (FriendModel) -> Unit): ListAdap
             tvItemFriendListName.text = item.name
             tvItemFriendListLevel.text = "LV ${item.level}"
             ivItemFriendListLevel.setImageResource(levelBadgeDrawable(item.level))
-            ivItemFriendListBackground.loadProfileBackground(item.backgroundImageUrl)
-            ivItemFriendListImage.loadProfileTurtle(item.turtleImageUrl, R.drawable.default_turtle)
+            ivItemFriendListBackground.loadProfileBackground(item.backgroundImageUrl, ProfileImagePlacement.FRIEND_BACKGROUND)
+            ivItemFriendListImage.loadProfileTurtle(item.turtleImageUrl, R.drawable.default_turtle, ProfileImagePlacement.FRIEND_TURTLE)
             ivItemSquareFriendListDelete.setOnClickListener { onDeleted(item) }
         }
     }

--- a/app/src/main/java/com/egobook/app/ui/square/adapter/ProfileImageLoader.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/adapter/ProfileImageLoader.kt
@@ -32,7 +32,8 @@ internal fun ImageView.loadProfileBackground(url: String?, placement: ProfileIma
     observeProfileFrameChanges(placement)
     Glide.with(this)
         .load(url)
-        .listener(profilePlacementListener(placement))
+        .error(R.drawable.default_background)
+        .listener(profilePlacementListener(placement, useDefaultBackgroundOnFailure = true))
         .into(this)
 }
 
@@ -80,7 +81,8 @@ internal fun ImageView.loadProfileTurtle(
 private fun ImageView.profilePlacementListener(
     placement: ProfileImagePlacement,
     turtleFallbackScaleX: Float? = null,
-    placeTurtleFallback: Boolean = false
+    placeTurtleFallback: Boolean = false,
+    useDefaultBackgroundOnFailure: Boolean = false
 ) =
     object : RequestListener<Drawable> {
         override fun onLoadFailed(
@@ -89,7 +91,10 @@ private fun ImageView.profilePlacementListener(
             target: Target<Drawable>,
             isFirstResource: Boolean
         ): Boolean {
-            if (turtleFallbackScaleX != null) {
+            if (useDefaultBackgroundOnFailure) {
+                stopObservingProfileFrameChanges()
+                scaleType = ImageView.ScaleType.CENTER_CROP
+            } else if (turtleFallbackScaleX != null) {
                 scaleX = turtleFallbackScaleX
                 stopObservingProfileFrameChanges()
                 if (placeTurtleFallback) {

--- a/app/src/main/java/com/egobook/app/ui/square/adapter/ProfileImageLoader.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/adapter/ProfileImageLoader.kt
@@ -13,11 +13,20 @@ import com.bumptech.glide.request.RequestListener
 import com.bumptech.glide.request.target.Target
 import com.egobook.app.ui.square.ProfileImagePlacement
 import com.egobook.app.ui.square.calculateProfileImageTransform
+import com.egobook.app.ui.square.hasRemoteProfileImage
+import com.egobook.app.R
 import java.util.WeakHashMap
 
 private val profileLayoutListeners = WeakHashMap<ImageView, View.OnLayoutChangeListener>()
 
 internal fun ImageView.loadProfileBackground(url: String?, placement: ProfileImagePlacement) {
+    if (!hasRemoteProfileImage(url)) {
+        Glide.with(this).clear(this)
+        stopObservingProfileFrameChanges()
+        scaleType = ImageView.ScaleType.CENTER_CROP
+        setImageResource(R.drawable.default_background)
+        return
+    }
     scaleType = ImageView.ScaleType.MATRIX
     observeProfileFrameChanges(placement)
     Glide.with(this)
@@ -31,6 +40,13 @@ internal fun ImageView.loadProfileTurtle(
     @DrawableRes fallback: Int,
     placement: ProfileImagePlacement
 ) {
+    if (!hasRemoteProfileImage(url)) {
+        Glide.with(this).clear(this)
+        stopObservingProfileFrameChanges()
+        scaleType = ImageView.ScaleType.FIT_CENTER
+        setImageResource(fallback)
+        return
+    }
     scaleType = ImageView.ScaleType.MATRIX
     observeProfileFrameChanges(placement)
     Glide.with(this)
@@ -66,7 +82,7 @@ private fun ImageView.profilePlacementListener(placement: ProfileImagePlacement)
     }
 
 private fun ImageView.observeProfileFrameChanges(placement: ProfileImagePlacement) {
-    profileLayoutListeners.remove(this)?.let(::removeOnLayoutChangeListener)
+    stopObservingProfileFrameChanges()
     val listener = View.OnLayoutChangeListener { view, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom ->
         if (right - left != oldRight - oldLeft || bottom - top != oldBottom - oldTop) {
             (view as ImageView).applyProfilePlacement(placement)
@@ -74,6 +90,10 @@ private fun ImageView.observeProfileFrameChanges(placement: ProfileImagePlacemen
     }
     profileLayoutListeners[this] = listener
     addOnLayoutChangeListener(listener)
+}
+
+private fun ImageView.stopObservingProfileFrameChanges() {
+    profileLayoutListeners.remove(this)?.let(::removeOnLayoutChangeListener)
 }
 
 private fun ImageView.applyProfilePlacementWhenLaidOut(placement: ProfileImagePlacement) {

--- a/app/src/main/java/com/egobook/app/ui/square/adapter/ProfileImageLoader.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/adapter/ProfileImageLoader.kt
@@ -14,6 +14,7 @@ import com.bumptech.glide.request.target.Target
 import com.egobook.app.ui.square.ProfileImagePlacement
 import com.egobook.app.ui.square.calculateProfileImageTransform
 import com.egobook.app.ui.square.hasRemoteProfileImage
+import com.egobook.app.ui.square.profileTurtleScaleX
 import com.egobook.app.R
 import java.util.WeakHashMap
 
@@ -40,6 +41,7 @@ internal fun ImageView.loadProfileTurtle(
     @DrawableRes fallback: Int,
     placement: ProfileImagePlacement
 ) {
+    scaleX = profileTurtleScaleX(url)
     if (!hasRemoteProfileImage(url)) {
         Glide.with(this).clear(this)
         stopObservingProfileFrameChanges()
@@ -53,11 +55,14 @@ internal fun ImageView.loadProfileTurtle(
         .load(url)
         .fallback(fallback)
         .error(fallback)
-        .listener(profilePlacementListener(placement))
+        .listener(profilePlacementListener(placement, mirrorFallback = true))
         .into(this)
 }
 
-private fun ImageView.profilePlacementListener(placement: ProfileImagePlacement) =
+private fun ImageView.profilePlacementListener(
+    placement: ProfileImagePlacement,
+    mirrorFallback: Boolean = false
+) =
     object : RequestListener<Drawable> {
         override fun onLoadFailed(
             error: GlideException?,
@@ -65,7 +70,13 @@ private fun ImageView.profilePlacementListener(placement: ProfileImagePlacement)
             target: Target<Drawable>,
             isFirstResource: Boolean
         ): Boolean {
-            post { applyProfilePlacementWhenLaidOut(placement) }
+            if (mirrorFallback) {
+                scaleX = -1f
+                stopObservingProfileFrameChanges()
+                scaleType = ImageView.ScaleType.FIT_CENTER
+            } else {
+                post { applyProfilePlacementWhenLaidOut(placement) }
+            }
             return false
         }
 
@@ -76,6 +87,10 @@ private fun ImageView.profilePlacementListener(placement: ProfileImagePlacement)
             dataSource: DataSource,
             isFirstResource: Boolean
         ): Boolean {
+            if (mirrorFallback) {
+                scaleX = 1f
+                scaleType = ImageView.ScaleType.MATRIX
+            }
             post { applyProfilePlacementWhenLaidOut(placement) }
             return false
         }

--- a/app/src/main/java/com/egobook/app/ui/square/adapter/ProfileImageLoader.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/adapter/ProfileImageLoader.kt
@@ -22,6 +22,7 @@ internal fun ImageView.loadProfileBackground(url: String?, placement: ProfileIma
     observeProfileFrameChanges(placement)
     Glide.with(this)
         .load(url)
+        .override(Target.SIZE_ORIGINAL)
         .listener(profilePlacementListener(placement))
         .into(this)
 }
@@ -35,6 +36,7 @@ internal fun ImageView.loadProfileTurtle(
     observeProfileFrameChanges(placement)
     Glide.with(this)
         .load(url)
+        .override(Target.SIZE_ORIGINAL)
         .fallback(fallback)
         .error(fallback)
         .listener(profilePlacementListener(placement))

--- a/app/src/main/java/com/egobook/app/ui/square/adapter/ProfileImageLoader.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/adapter/ProfileImageLoader.kt
@@ -1,19 +1,103 @@
 package com.egobook.app.ui.square.adapter
 
+import android.graphics.Matrix
+import android.graphics.drawable.Drawable
+import android.view.View
 import android.widget.ImageView
 import androidx.annotation.DrawableRes
+import androidx.core.view.doOnLayout
 import com.bumptech.glide.Glide
+import com.bumptech.glide.load.DataSource
+import com.bumptech.glide.load.engine.GlideException
+import com.bumptech.glide.request.RequestListener
+import com.bumptech.glide.request.target.Target
+import com.egobook.app.ui.square.ProfileImagePlacement
+import com.egobook.app.ui.square.calculateProfileImageTransform
+import java.util.WeakHashMap
 
-internal fun ImageView.loadProfileBackground(url: String?) {
+private val profileLayoutListeners = WeakHashMap<ImageView, View.OnLayoutChangeListener>()
+
+internal fun ImageView.loadProfileBackground(url: String?, placement: ProfileImagePlacement) {
+    scaleType = ImageView.ScaleType.MATRIX
+    observeProfileFrameChanges(placement)
     Glide.with(this)
         .load(url)
+        .listener(profilePlacementListener(placement))
         .into(this)
 }
 
-internal fun ImageView.loadProfileTurtle(url: String?, @DrawableRes fallback: Int) {
+internal fun ImageView.loadProfileTurtle(
+    url: String?,
+    @DrawableRes fallback: Int,
+    placement: ProfileImagePlacement
+) {
+    scaleType = ImageView.ScaleType.MATRIX
+    observeProfileFrameChanges(placement)
     Glide.with(this)
         .load(url)
         .fallback(fallback)
         .error(fallback)
+        .listener(profilePlacementListener(placement))
         .into(this)
+}
+
+private fun ImageView.profilePlacementListener(placement: ProfileImagePlacement) =
+    object : RequestListener<Drawable> {
+        override fun onLoadFailed(
+            error: GlideException?,
+            model: Any?,
+            target: Target<Drawable>,
+            isFirstResource: Boolean
+        ): Boolean {
+            post { applyProfilePlacementWhenLaidOut(placement) }
+            return false
+        }
+
+        override fun onResourceReady(
+            resource: Drawable,
+            model: Any,
+            target: Target<Drawable>?,
+            dataSource: DataSource,
+            isFirstResource: Boolean
+        ): Boolean {
+            post { applyProfilePlacementWhenLaidOut(placement) }
+            return false
+        }
+    }
+
+private fun ImageView.observeProfileFrameChanges(placement: ProfileImagePlacement) {
+    profileLayoutListeners.remove(this)?.let(::removeOnLayoutChangeListener)
+    val listener = View.OnLayoutChangeListener { view, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom ->
+        if (right - left != oldRight - oldLeft || bottom - top != oldBottom - oldTop) {
+            (view as ImageView).applyProfilePlacement(placement)
+        }
+    }
+    profileLayoutListeners[this] = listener
+    addOnLayoutChangeListener(listener)
+}
+
+private fun ImageView.applyProfilePlacementWhenLaidOut(placement: ProfileImagePlacement) {
+    doOnLayout { applyProfilePlacement(placement) }
+}
+
+private fun ImageView.applyProfilePlacement(placement: ProfileImagePlacement) {
+    val currentDrawable = drawable ?: return
+    val drawableWidth = currentDrawable.intrinsicWidth.takeIf { it > 0 } ?: return
+    val drawableHeight = currentDrawable.intrinsicHeight.takeIf { it > 0 } ?: return
+    val contentWidth = width - paddingLeft - paddingRight
+    val contentHeight = height - paddingTop - paddingBottom
+    if (contentWidth <= 0 || contentHeight <= 0) return
+
+    val transform = calculateProfileImageTransform(
+        frameWidth = contentWidth,
+        frameHeight = contentHeight,
+        imageWidth = drawableWidth,
+        imageHeight = drawableHeight,
+        placement = placement
+    )
+
+    imageMatrix = Matrix().apply {
+        setScale(transform.scale, transform.scale)
+        postTranslate(transform.translateX, transform.translateY)
+    }
 }

--- a/app/src/main/java/com/egobook/app/ui/square/adapter/ProfileImageLoader.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/adapter/ProfileImageLoader.kt
@@ -40,14 +40,21 @@ internal fun ImageView.loadProfileTurtle(
     url: String?,
     @DrawableRes fallback: Int,
     placement: ProfileImagePlacement,
-    mirrorFallback: Boolean = false
+    mirrorFallback: Boolean = false,
+    placeFallback: Boolean = false
 ) {
     scaleX = profileTurtleScaleX(url, mirrorFallback)
     if (!hasRemoteProfileImage(url)) {
         Glide.with(this).clear(this)
         stopObservingProfileFrameChanges()
-        scaleType = ImageView.ScaleType.FIT_CENTER
         setImageResource(fallback)
+        if (placeFallback) {
+            scaleType = ImageView.ScaleType.MATRIX
+            observeProfileFrameChanges(placement)
+            applyProfilePlacementWhenLaidOut(placement)
+        } else {
+            scaleType = ImageView.ScaleType.FIT_CENTER
+        }
         return
     }
     scaleType = ImageView.ScaleType.MATRIX
@@ -63,7 +70,8 @@ internal fun ImageView.loadProfileTurtle(
                     url,
                     mirrorFallback,
                     isFallbackDisplayed = true
-                )
+                ),
+                placeTurtleFallback = placeFallback
             )
         )
         .into(this)
@@ -71,7 +79,8 @@ internal fun ImageView.loadProfileTurtle(
 
 private fun ImageView.profilePlacementListener(
     placement: ProfileImagePlacement,
-    turtleFallbackScaleX: Float? = null
+    turtleFallbackScaleX: Float? = null,
+    placeTurtleFallback: Boolean = false
 ) =
     object : RequestListener<Drawable> {
         override fun onLoadFailed(
@@ -83,7 +92,13 @@ private fun ImageView.profilePlacementListener(
             if (turtleFallbackScaleX != null) {
                 scaleX = turtleFallbackScaleX
                 stopObservingProfileFrameChanges()
-                scaleType = ImageView.ScaleType.FIT_CENTER
+                if (placeTurtleFallback) {
+                    scaleType = ImageView.ScaleType.MATRIX
+                    observeProfileFrameChanges(placement)
+                    post { applyProfilePlacementWhenLaidOut(placement) }
+                } else {
+                    scaleType = ImageView.ScaleType.FIT_CENTER
+                }
             } else {
                 post { applyProfilePlacementWhenLaidOut(placement) }
             }

--- a/app/src/main/java/com/egobook/app/ui/square/adapter/ProfileImageLoader.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/adapter/ProfileImageLoader.kt
@@ -39,9 +39,10 @@ internal fun ImageView.loadProfileBackground(url: String?, placement: ProfileIma
 internal fun ImageView.loadProfileTurtle(
     url: String?,
     @DrawableRes fallback: Int,
-    placement: ProfileImagePlacement
+    placement: ProfileImagePlacement,
+    mirrorFallback: Boolean = false
 ) {
-    scaleX = profileTurtleScaleX(url)
+    scaleX = profileTurtleScaleX(url, mirrorFallback)
     if (!hasRemoteProfileImage(url)) {
         Glide.with(this).clear(this)
         stopObservingProfileFrameChanges()
@@ -55,13 +56,22 @@ internal fun ImageView.loadProfileTurtle(
         .load(url)
         .fallback(fallback)
         .error(fallback)
-        .listener(profilePlacementListener(placement, mirrorFallback = true))
+        .listener(
+            profilePlacementListener(
+                placement,
+                turtleFallbackScaleX = profileTurtleScaleX(
+                    url,
+                    mirrorFallback,
+                    isFallbackDisplayed = true
+                )
+            )
+        )
         .into(this)
 }
 
 private fun ImageView.profilePlacementListener(
     placement: ProfileImagePlacement,
-    mirrorFallback: Boolean = false
+    turtleFallbackScaleX: Float? = null
 ) =
     object : RequestListener<Drawable> {
         override fun onLoadFailed(
@@ -70,8 +80,8 @@ private fun ImageView.profilePlacementListener(
             target: Target<Drawable>,
             isFirstResource: Boolean
         ): Boolean {
-            if (mirrorFallback) {
-                scaleX = -1f
+            if (turtleFallbackScaleX != null) {
+                scaleX = turtleFallbackScaleX
                 stopObservingProfileFrameChanges()
                 scaleType = ImageView.ScaleType.FIT_CENTER
             } else {
@@ -87,7 +97,7 @@ private fun ImageView.profilePlacementListener(
             dataSource: DataSource,
             isFirstResource: Boolean
         ): Boolean {
-            if (mirrorFallback) {
+            if (turtleFallbackScaleX != null) {
                 scaleX = 1f
                 scaleType = ImageView.ScaleType.MATRIX
             }

--- a/app/src/main/java/com/egobook/app/ui/square/adapter/ProfileImageLoader.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/adapter/ProfileImageLoader.kt
@@ -1,0 +1,19 @@
+package com.egobook.app.ui.square.adapter
+
+import android.widget.ImageView
+import androidx.annotation.DrawableRes
+import com.bumptech.glide.Glide
+
+internal fun ImageView.loadProfileBackground(url: String?) {
+    Glide.with(this)
+        .load(url)
+        .into(this)
+}
+
+internal fun ImageView.loadProfileTurtle(url: String?, @DrawableRes fallback: Int) {
+    Glide.with(this)
+        .load(url)
+        .fallback(fallback)
+        .error(fallback)
+        .into(this)
+}

--- a/app/src/main/java/com/egobook/app/ui/square/adapter/ProfileImageLoader.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/adapter/ProfileImageLoader.kt
@@ -22,7 +22,6 @@ internal fun ImageView.loadProfileBackground(url: String?, placement: ProfileIma
     observeProfileFrameChanges(placement)
     Glide.with(this)
         .load(url)
-        .override(Target.SIZE_ORIGINAL)
         .listener(profilePlacementListener(placement))
         .into(this)
 }
@@ -36,7 +35,6 @@ internal fun ImageView.loadProfileTurtle(
     observeProfileFrameChanges(placement)
     Glide.with(this)
         .load(url)
-        .override(Target.SIZE_ORIGINAL)
         .fallback(fallback)
         .error(fallback)
         .listener(profilePlacementListener(placement))

--- a/app/src/main/java/com/egobook/app/ui/square/adapter/SquareAllRepliesAdapter.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/adapter/SquareAllRepliesAdapter.kt
@@ -51,7 +51,8 @@ class SquareAllRepliesAdapter(private val onReportClick: (Long) -> Unit): Paging
             ivItemSquareQuestionReplyUserImage.loadProfileTurtle(
                 item.turtleImageUrl,
                 R.drawable.img_temp_square_user_thumbnail,
-                ProfileImagePlacement.PLAZA_TURTLE
+                ProfileImagePlacement.PLAZA_TURTLE,
+                mirrorFallback = true
             )
             applyContentExpandedState(expandedAnswerIds.contains(item.answerId))
 

--- a/app/src/main/java/com/egobook/app/ui/square/adapter/SquareAllRepliesAdapter.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/adapter/SquareAllRepliesAdapter.kt
@@ -10,6 +10,7 @@ import com.egobook.app.R
 import com.egobook.app.databinding.ItemSquareQuestionReplyBinding
 import com.egobook.app.ui.square.model.question.UserTodayQuestionAnswerItemModel
 import com.egobook.app.ui.square.levelBadgeDrawable
+import com.egobook.app.ui.square.ProfileImagePlacement
 
 class SquareAllRepliesAdapter(private val onReportClick: (Long) -> Unit): PagingDataAdapter<UserTodayQuestionAnswerItemModel, SquareAllRepliesAdapter.SquareAllRepliesViewHolder>(diffUtil) {
     private val expandedAnswerIds = mutableSetOf<Long>()
@@ -41,10 +42,14 @@ class SquareAllRepliesAdapter(private val onReportClick: (Long) -> Unit): Paging
             tvItemSquareQuestionReplyUserContent.text = item.content
             tvItemSquareQuestionReplyUserLevel.text = "LV ${item.level}"
             ivItemSquareQuestionReplyUserLevel.setImageResource(levelBadgeDrawable(item.level))
-            ivItemSquareQuestionReplyUserBackground.loadProfileBackground(item.backgroundImageUrl)
+            ivItemSquareQuestionReplyUserBackground.loadProfileBackground(
+                item.backgroundImageUrl,
+                ProfileImagePlacement.PLAZA_BACKGROUND
+            )
             ivItemSquareQuestionReplyUserImage.loadProfileTurtle(
                 item.turtleImageUrl,
-                R.drawable.img_temp_square_user_thumbnail
+                R.drawable.img_temp_square_user_thumbnail,
+                ProfileImagePlacement.PLAZA_TURTLE
             )
             applyContentExpandedState(expandedAnswerIds.contains(item.answerId))
 

--- a/app/src/main/java/com/egobook/app/ui/square/adapter/SquareAllRepliesAdapter.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/adapter/SquareAllRepliesAdapter.kt
@@ -6,6 +6,7 @@ import android.view.ViewGroup
 import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
+import com.egobook.app.R
 import com.egobook.app.databinding.ItemSquareQuestionReplyBinding
 import com.egobook.app.ui.square.model.question.UserTodayQuestionAnswerItemModel
 
@@ -37,6 +38,11 @@ class SquareAllRepliesAdapter(private val onReportClick: (Long) -> Unit): Paging
     ): RecyclerView.ViewHolder(binding.root) {
         fun bind(item: UserTodayQuestionAnswerItemModel) = with(binding) {
             tvItemSquareQuestionReplyUserContent.text = item.content
+            ivItemSquareQuestionReplyUserBackground.loadProfileBackground(item.backgroundImageUrl)
+            ivItemSquareQuestionReplyUserImage.loadProfileTurtle(
+                item.turtleImageUrl,
+                R.drawable.img_temp_square_user_thumbnail
+            )
             applyContentExpandedState(expandedAnswerIds.contains(item.answerId))
 
             root.setOnClickListener {

--- a/app/src/main/java/com/egobook/app/ui/square/adapter/SquareAllRepliesAdapter.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/adapter/SquareAllRepliesAdapter.kt
@@ -11,6 +11,7 @@ import com.egobook.app.databinding.ItemSquareQuestionReplyBinding
 import com.egobook.app.ui.square.model.question.UserTodayQuestionAnswerItemModel
 import com.egobook.app.ui.square.levelBadgeDrawable
 import com.egobook.app.ui.square.ProfileImagePlacement
+import com.egobook.app.ui.square.tendencyIconDrawable
 
 class SquareAllRepliesAdapter(private val onReportClick: (Long) -> Unit): PagingDataAdapter<UserTodayQuestionAnswerItemModel, SquareAllRepliesAdapter.SquareAllRepliesViewHolder>(diffUtil) {
     private val expandedAnswerIds = mutableSetOf<Long>()
@@ -42,6 +43,7 @@ class SquareAllRepliesAdapter(private val onReportClick: (Long) -> Unit): Paging
             tvItemSquareQuestionReplyUserContent.text = item.content
             tvItemSquareQuestionReplyUserLevel.text = "LV ${item.level}"
             ivItemSquareQuestionReplyUserLevel.setImageResource(levelBadgeDrawable(item.level))
+            ivItemSquareQuestionReplySymbol.setImageResource(tendencyIconDrawable(item.topAbilityName))
             ivItemSquareQuestionReplyUserBackground.loadProfileBackground(
                 item.backgroundImageUrl,
                 ProfileImagePlacement.PLAZA_BACKGROUND

--- a/app/src/main/java/com/egobook/app/ui/square/adapter/SquareAllRepliesAdapter.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/adapter/SquareAllRepliesAdapter.kt
@@ -9,6 +9,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.egobook.app.R
 import com.egobook.app.databinding.ItemSquareQuestionReplyBinding
 import com.egobook.app.ui.square.model.question.UserTodayQuestionAnswerItemModel
+import com.egobook.app.ui.square.levelBadgeDrawable
 
 class SquareAllRepliesAdapter(private val onReportClick: (Long) -> Unit): PagingDataAdapter<UserTodayQuestionAnswerItemModel, SquareAllRepliesAdapter.SquareAllRepliesViewHolder>(diffUtil) {
     private val expandedAnswerIds = mutableSetOf<Long>()
@@ -38,6 +39,8 @@ class SquareAllRepliesAdapter(private val onReportClick: (Long) -> Unit): Paging
     ): RecyclerView.ViewHolder(binding.root) {
         fun bind(item: UserTodayQuestionAnswerItemModel) = with(binding) {
             tvItemSquareQuestionReplyUserContent.text = item.content
+            tvItemSquareQuestionReplyUserLevel.text = "LV ${item.level}"
+            ivItemSquareQuestionReplyUserLevel.setImageResource(levelBadgeDrawable(item.level))
             ivItemSquareQuestionReplyUserBackground.loadProfileBackground(item.backgroundImageUrl)
             ivItemSquareQuestionReplyUserImage.loadProfileTurtle(
                 item.turtleImageUrl,

--- a/app/src/main/java/com/egobook/app/ui/square/adapter/TodayQuestionFriendRepliesAdapter.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/adapter/TodayQuestionFriendRepliesAdapter.kt
@@ -28,7 +28,8 @@ class TodayQuestionFriendRepliesAdapter: PagingDataAdapter<UserTodayQuestionAnsw
             ivItemSquareFriendAnswerUserImage.loadProfileTurtle(
                 item.turtleImageUrl,
                 R.drawable.img_temp_square_user_thumbnail,
-                ProfileImagePlacement.PLAZA_TURTLE
+                ProfileImagePlacement.PLAZA_TURTLE,
+                mirrorFallback = true
             )
         }
     }

--- a/app/src/main/java/com/egobook/app/ui/square/adapter/TodayQuestionFriendRepliesAdapter.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/adapter/TodayQuestionFriendRepliesAdapter.kt
@@ -9,6 +9,7 @@ import com.egobook.app.R
 import com.egobook.app.databinding.ItemSquareFriendAnswerBinding
 import com.egobook.app.ui.square.model.question.UserTodayQuestionAnswerItemModel
 import com.egobook.app.ui.square.levelBadgeDrawable
+import com.egobook.app.ui.square.ProfileImagePlacement
 
 class TodayQuestionFriendRepliesAdapter: PagingDataAdapter<UserTodayQuestionAnswerItemModel, TodayQuestionFriendRepliesAdapter.TodayQuestionFriendRepliesViewHolder>(diffUtil) {
 
@@ -18,10 +19,14 @@ class TodayQuestionFriendRepliesAdapter: PagingDataAdapter<UserTodayQuestionAnsw
             tvItemSquareFriendAnswerUserContent.text = item.content
             tvItemSquareFriendAnswerUserLevel.text = "LV ${item.level}"
             ivItemSquareFriendAnswerUserLevel.setImageResource(levelBadgeDrawable(item.level))
-            ivItemSquareFriendAnswerUserBackground.loadProfileBackground(item.backgroundImageUrl)
+            ivItemSquareFriendAnswerUserBackground.loadProfileBackground(
+                item.backgroundImageUrl,
+                ProfileImagePlacement.PLAZA_BACKGROUND
+            )
             ivItemSquareFriendAnswerUserImage.loadProfileTurtle(
                 item.turtleImageUrl,
-                R.drawable.img_temp_square_user_thumbnail
+                R.drawable.img_temp_square_user_thumbnail,
+                ProfileImagePlacement.PLAZA_TURTLE
             )
         }
     }

--- a/app/src/main/java/com/egobook/app/ui/square/adapter/TodayQuestionFriendRepliesAdapter.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/adapter/TodayQuestionFriendRepliesAdapter.kt
@@ -8,6 +8,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.egobook.app.R
 import com.egobook.app.databinding.ItemSquareFriendAnswerBinding
 import com.egobook.app.ui.square.model.question.UserTodayQuestionAnswerItemModel
+import com.egobook.app.ui.square.levelBadgeDrawable
 
 class TodayQuestionFriendRepliesAdapter: PagingDataAdapter<UserTodayQuestionAnswerItemModel, TodayQuestionFriendRepliesAdapter.TodayQuestionFriendRepliesViewHolder>(diffUtil) {
 
@@ -15,6 +16,8 @@ class TodayQuestionFriendRepliesAdapter: PagingDataAdapter<UserTodayQuestionAnsw
         fun bind(item: UserTodayQuestionAnswerItemModel) = with(binding) {
             tvItemSquareFriendAnswerUserName.text = item.nickname
             tvItemSquareFriendAnswerUserContent.text = item.content
+            tvItemSquareFriendAnswerUserLevel.text = "LV ${item.level}"
+            ivItemSquareFriendAnswerUserLevel.setImageResource(levelBadgeDrawable(item.level))
             ivItemSquareFriendAnswerUserBackground.loadProfileBackground(item.backgroundImageUrl)
             ivItemSquareFriendAnswerUserImage.loadProfileTurtle(
                 item.turtleImageUrl,

--- a/app/src/main/java/com/egobook/app/ui/square/adapter/TodayQuestionFriendRepliesAdapter.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/adapter/TodayQuestionFriendRepliesAdapter.kt
@@ -5,6 +5,7 @@ import android.view.ViewGroup
 import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
+import com.egobook.app.R
 import com.egobook.app.databinding.ItemSquareFriendAnswerBinding
 import com.egobook.app.ui.square.model.question.UserTodayQuestionAnswerItemModel
 
@@ -14,6 +15,11 @@ class TodayQuestionFriendRepliesAdapter: PagingDataAdapter<UserTodayQuestionAnsw
         fun bind(item: UserTodayQuestionAnswerItemModel) = with(binding) {
             tvItemSquareFriendAnswerUserName.text = item.nickname
             tvItemSquareFriendAnswerUserContent.text = item.content
+            ivItemSquareFriendAnswerUserBackground.loadProfileBackground(item.backgroundImageUrl)
+            ivItemSquareFriendAnswerUserImage.loadProfileTurtle(
+                item.turtleImageUrl,
+                R.drawable.img_temp_square_user_thumbnail
+            )
         }
     }
 

--- a/app/src/main/java/com/egobook/app/ui/square/adapter/TodayQuestionFriendRepliesAdapter.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/adapter/TodayQuestionFriendRepliesAdapter.kt
@@ -10,6 +10,7 @@ import com.egobook.app.databinding.ItemSquareFriendAnswerBinding
 import com.egobook.app.ui.square.model.question.UserTodayQuestionAnswerItemModel
 import com.egobook.app.ui.square.levelBadgeDrawable
 import com.egobook.app.ui.square.ProfileImagePlacement
+import com.egobook.app.ui.square.tendencyIconDrawable
 
 class TodayQuestionFriendRepliesAdapter: PagingDataAdapter<UserTodayQuestionAnswerItemModel, TodayQuestionFriendRepliesAdapter.TodayQuestionFriendRepliesViewHolder>(diffUtil) {
 
@@ -19,6 +20,7 @@ class TodayQuestionFriendRepliesAdapter: PagingDataAdapter<UserTodayQuestionAnsw
             tvItemSquareFriendAnswerUserContent.text = item.content
             tvItemSquareFriendAnswerUserLevel.text = "LV ${item.level}"
             ivItemSquareFriendAnswerUserLevel.setImageResource(levelBadgeDrawable(item.level))
+            ivItemSquareFriendAnswerSymbol.setImageResource(tendencyIconDrawable(item.topAbilityName))
             ivItemSquareFriendAnswerUserBackground.loadProfileBackground(
                 item.backgroundImageUrl,
                 ProfileImagePlacement.PLAZA_BACKGROUND

--- a/app/src/main/java/com/egobook/app/ui/square/model/friend/FriendListModel.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/model/friend/FriendListModel.kt
@@ -10,7 +10,9 @@ data class FriendListModel(
 data class FriendModel(
     val id: Long,
     val name: String,
-    val level: Long
+    val level: Long,
+    val turtleImageUrl: String? = null,
+    val backgroundImageUrl: String? = null
 )
 
 fun FriendList.toPresentation(): FriendListModel = FriendListModel(
@@ -21,5 +23,7 @@ fun FriendList.toPresentation(): FriendListModel = FriendListModel(
 fun Friend.toPresentation(): FriendModel = FriendModel(
     id = id,
     name = name,
-    level = level
+    level = level,
+    turtleImageUrl = turtleImageUrl,
+    backgroundImageUrl = backgroundImageUrl
 )

--- a/app/src/main/java/com/egobook/app/ui/square/model/friend/FriendRequestModel.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/model/friend/FriendRequestModel.kt
@@ -7,11 +7,15 @@ data class FriendRequestModel(
     val userId: Long,
     val nickname: String,
     val level: Long,
+    val turtleImageUrl: String? = null,
+    val backgroundImageUrl: String? = null,
 )
 
 fun FriendRequest.toPresentation(): FriendRequestModel = FriendRequestModel(
     requestId = requestId,
     userId = userId,
     nickname = nickname,
-    level = level
+    level = level,
+    turtleImageUrl = turtleImageUrl,
+    backgroundImageUrl = backgroundImageUrl
 )

--- a/app/src/main/java/com/egobook/app/ui/square/model/friend/SearchUserModel.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/model/friend/SearchUserModel.kt
@@ -6,13 +6,15 @@ data class SearchUserModel(
     val userId: Long,
     val nickname: String,
     val level: Long,
-    val profileImageUrl: String? = null
+    val turtleImageUrl: String? = null,
+    val backgroundImageUrl: String? = null
 )
 
 fun SearchUser.toPresentation(): SearchUserModel = SearchUserModel(
     userId = userId,
     nickname = nickname,
     level = level,
-    profileImageUrl = profileImageUrl
+    turtleImageUrl = turtleImageUrl,
+    backgroundImageUrl = backgroundImageUrl
 )
 

--- a/app/src/main/java/com/egobook/app/ui/square/model/question/UserTodayQuestionAnswerModel.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/model/question/UserTodayQuestionAnswerModel.kt
@@ -15,7 +15,9 @@ data class UserTodayQuestionAnswerItemModel(
     val userId: Long,
     val nickname: String,
     val content: String,
-    val createdAt: String
+    val createdAt: String,
+    val turtleImageUrl: String? = null,
+    val backgroundImageUrl: String? = null
 )
 
 fun UserTodayQuestionAnswerItem.toPresentation() = UserTodayQuestionAnswerItemModel(
@@ -23,7 +25,9 @@ fun UserTodayQuestionAnswerItem.toPresentation() = UserTodayQuestionAnswerItemMo
     userId = userId,
     nickname = nickname,
     content = content,
-    createdAt = createdAt
+    createdAt = createdAt,
+    turtleImageUrl = turtleImageUrl,
+    backgroundImageUrl = backgroundImageUrl
 )
 
 fun UserTodayQuestionAnswer.toPresentation() = UserTodayQuestionAnswerModel(

--- a/app/src/main/java/com/egobook/app/ui/square/model/question/UserTodayQuestionAnswerModel.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/model/question/UserTodayQuestionAnswerModel.kt
@@ -16,6 +16,7 @@ data class UserTodayQuestionAnswerItemModel(
     val nickname: String,
     val content: String,
     val createdAt: String,
+    val level: Long,
     val turtleImageUrl: String? = null,
     val backgroundImageUrl: String? = null
 )
@@ -26,6 +27,7 @@ fun UserTodayQuestionAnswerItem.toPresentation() = UserTodayQuestionAnswerItemMo
     nickname = nickname,
     content = content,
     createdAt = createdAt,
+    level = level,
     turtleImageUrl = turtleImageUrl,
     backgroundImageUrl = backgroundImageUrl
 )

--- a/app/src/main/java/com/egobook/app/ui/square/model/question/UserTodayQuestionAnswerModel.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/model/question/UserTodayQuestionAnswerModel.kt
@@ -17,6 +17,7 @@ data class UserTodayQuestionAnswerItemModel(
     val content: String,
     val createdAt: String,
     val level: Long,
+    val topAbilityName: String? = null,
     val turtleImageUrl: String? = null,
     val backgroundImageUrl: String? = null
 )
@@ -28,6 +29,7 @@ fun UserTodayQuestionAnswerItem.toPresentation() = UserTodayQuestionAnswerItemMo
     content = content,
     createdAt = createdAt,
     level = level,
+    topAbilityName = topAbilityName,
     turtleImageUrl = turtleImageUrl,
     backgroundImageUrl = backgroundImageUrl
 )

--- a/app/src/main/java/com/egobook/app/ui/square/view/FriendsPendingListFragment.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/view/FriendsPendingListFragment.kt
@@ -25,6 +25,7 @@ import com.egobook.app.ui.square.model.friend.FriendRequestModel
 import com.egobook.app.ui.square.adapter.loadProfileBackground
 import com.egobook.app.ui.square.adapter.loadProfileTurtle
 import com.egobook.app.ui.square.levelBadgeDrawable
+import com.egobook.app.ui.square.ProfileImagePlacement
 import com.egobook.app.ui.square.viewmodel.FriendsViewModel
 import com.egobook.app.util.UiState
 import kotlinx.coroutines.launch
@@ -82,8 +83,8 @@ class FriendsPendingListFragment : Fragment(R.layout.fragment_friends_pending_li
                                         itemBinding.tvItemFriendPendingListName.text = friendRequest.nickname
                                         itemBinding.tvItemFriendPendingListLevel.text = "LV ${friendRequest.level}"
                                         itemBinding.ivItemFriendPendingListLevel.setImageResource(levelBadgeDrawable(friendRequest.level))
-                                        itemBinding.ivItemFriendPendingListBackground.loadProfileBackground(friendRequest.backgroundImageUrl)
-                                        itemBinding.ivItemFriendPendingListImage.loadProfileTurtle(friendRequest.turtleImageUrl, R.drawable.default_turtle)
+                                        itemBinding.ivItemFriendPendingListBackground.loadProfileBackground(friendRequest.backgroundImageUrl, ProfileImagePlacement.FRIEND_BACKGROUND)
+                                        itemBinding.ivItemFriendPendingListImage.loadProfileTurtle(friendRequest.turtleImageUrl, R.drawable.default_turtle, ProfileImagePlacement.FRIEND_TURTLE)
                                         itemBinding.btnItemSquareFriendPendingListDeny.setOnClickListener {
                                             viewModel.rejectFriendRequest(requestId = friendRequest.requestId)
                                         }
@@ -123,8 +124,8 @@ class FriendsPendingListFragment : Fragment(R.layout.fragment_friends_pending_li
                                         itemBinding.tvItemFriendPendingSentListName.text = friendRequest.nickname
                                         itemBinding.tvItemFriendPendingSentListLevel.text = "LV ${friendRequest.level}"
                                         itemBinding.ivItemFriendPendingSentListLevel.setImageResource(levelBadgeDrawable(friendRequest.level))
-                                        itemBinding.ivItemFriendPendingSentListBackground.loadProfileBackground(friendRequest.backgroundImageUrl)
-                                        itemBinding.ivItemFriendPendingSentListImage.loadProfileTurtle(friendRequest.turtleImageUrl, R.drawable.default_turtle)
+                                        itemBinding.ivItemFriendPendingSentListBackground.loadProfileBackground(friendRequest.backgroundImageUrl, ProfileImagePlacement.FRIEND_BACKGROUND)
+                                        itemBinding.ivItemFriendPendingSentListImage.loadProfileTurtle(friendRequest.turtleImageUrl, R.drawable.default_turtle, ProfileImagePlacement.FRIEND_TURTLE)
                                         itemBinding.btnItemSquareFriendPendingSentListCancel.setOnClickListener {
                                             viewModel.cancelFriendRequest(requestId = friendRequest.requestId)
                                         }

--- a/app/src/main/java/com/egobook/app/ui/square/view/FriendsPendingListFragment.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/view/FriendsPendingListFragment.kt
@@ -22,6 +22,9 @@ import com.egobook.app.databinding.FragmentFriendsPendingListBinding
 import com.egobook.app.databinding.ItemSquareFriendPendingReceivedListBinding
 import com.egobook.app.databinding.ItemSquareFriendPendingSentListBinding
 import com.egobook.app.ui.square.model.friend.FriendRequestModel
+import com.egobook.app.ui.square.adapter.loadProfileBackground
+import com.egobook.app.ui.square.adapter.loadProfileTurtle
+import com.egobook.app.ui.square.levelBadgeDrawable
 import com.egobook.app.ui.square.viewmodel.FriendsViewModel
 import com.egobook.app.util.UiState
 import kotlinx.coroutines.launch
@@ -78,6 +81,9 @@ class FriendsPendingListFragment : Fragment(R.layout.fragment_friends_pending_li
                                         val itemBinding = ItemSquareFriendPendingReceivedListBinding.bind(itemView)
                                         itemBinding.tvItemFriendPendingListName.text = friendRequest.nickname
                                         itemBinding.tvItemFriendPendingListLevel.text = "LV ${friendRequest.level}"
+                                        itemBinding.ivItemFriendPendingListLevel.setImageResource(levelBadgeDrawable(friendRequest.level))
+                                        itemBinding.ivItemFriendPendingListBackground.loadProfileBackground(friendRequest.backgroundImageUrl)
+                                        itemBinding.ivItemFriendPendingListImage.loadProfileTurtle(friendRequest.turtleImageUrl, R.drawable.default_turtle)
                                         itemBinding.btnItemSquareFriendPendingListDeny.setOnClickListener {
                                             viewModel.rejectFriendRequest(requestId = friendRequest.requestId)
                                         }
@@ -116,6 +122,9 @@ class FriendsPendingListFragment : Fragment(R.layout.fragment_friends_pending_li
                                         val itemBinding = ItemSquareFriendPendingSentListBinding.bind(itemView)
                                         itemBinding.tvItemFriendPendingSentListName.text = friendRequest.nickname
                                         itemBinding.tvItemFriendPendingSentListLevel.text = "LV ${friendRequest.level}"
+                                        itemBinding.ivItemFriendPendingSentListLevel.setImageResource(levelBadgeDrawable(friendRequest.level))
+                                        itemBinding.ivItemFriendPendingSentListBackground.loadProfileBackground(friendRequest.backgroundImageUrl)
+                                        itemBinding.ivItemFriendPendingSentListImage.loadProfileTurtle(friendRequest.turtleImageUrl, R.drawable.default_turtle)
                                         itemBinding.btnItemSquareFriendPendingSentListCancel.setOnClickListener {
                                             viewModel.cancelFriendRequest(requestId = friendRequest.requestId)
                                         }

--- a/app/src/main/java/com/egobook/app/ui/square/view/FriendsPendingListFragment.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/view/FriendsPendingListFragment.kt
@@ -84,7 +84,7 @@ class FriendsPendingListFragment : Fragment(R.layout.fragment_friends_pending_li
                                         itemBinding.tvItemFriendPendingListLevel.text = "LV ${friendRequest.level}"
                                         itemBinding.ivItemFriendPendingListLevel.setImageResource(levelBadgeDrawable(friendRequest.level))
                                         itemBinding.ivItemFriendPendingListBackground.loadProfileBackground(friendRequest.backgroundImageUrl, ProfileImagePlacement.FRIEND_BACKGROUND)
-                                        itemBinding.ivItemFriendPendingListImage.loadProfileTurtle(friendRequest.turtleImageUrl, R.drawable.default_turtle, ProfileImagePlacement.FRIEND_TURTLE)
+                                        itemBinding.ivItemFriendPendingListImage.loadProfileTurtle(friendRequest.turtleImageUrl, R.drawable.default_turtle, ProfileImagePlacement.FRIEND_TURTLE, placeFallback = true)
                                         itemBinding.btnItemSquareFriendPendingListDeny.setOnClickListener {
                                             viewModel.rejectFriendRequest(requestId = friendRequest.requestId)
                                         }
@@ -125,7 +125,7 @@ class FriendsPendingListFragment : Fragment(R.layout.fragment_friends_pending_li
                                         itemBinding.tvItemFriendPendingSentListLevel.text = "LV ${friendRequest.level}"
                                         itemBinding.ivItemFriendPendingSentListLevel.setImageResource(levelBadgeDrawable(friendRequest.level))
                                         itemBinding.ivItemFriendPendingSentListBackground.loadProfileBackground(friendRequest.backgroundImageUrl, ProfileImagePlacement.FRIEND_BACKGROUND)
-                                        itemBinding.ivItemFriendPendingSentListImage.loadProfileTurtle(friendRequest.turtleImageUrl, R.drawable.default_turtle, ProfileImagePlacement.FRIEND_TURTLE)
+                                        itemBinding.ivItemFriendPendingSentListImage.loadProfileTurtle(friendRequest.turtleImageUrl, R.drawable.default_turtle, ProfileImagePlacement.FRIEND_TURTLE, placeFallback = true)
                                         itemBinding.btnItemSquareFriendPendingSentListCancel.setOnClickListener {
                                             viewModel.cancelFriendRequest(requestId = friendRequest.requestId)
                                         }

--- a/app/src/main/res/layout/item_search_friend.xml
+++ b/app/src/main/res/layout/item_search_friend.xml
@@ -11,17 +11,23 @@
         android:id="@+id/cv_add_friend_search_image"
         android:layout_width="145dp"
         android:layout_height="0dp"
+        android:clipToOutline="true"
         app:cardCornerRadius="12dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:strokeWidth="0dp">
+        <ImageView
+            android:id="@+id/iv_add_friend_search_background"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scaleType="centerCrop" />
 
         <ImageView
             android:id="@+id/iv_add_friend_search_image"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:scaleType="centerCrop"
+            android:scaleType="fitCenter"
             tools:src="@drawable/default_turtle" />
     </com.google.android.material.card.MaterialCardView>
 

--- a/app/src/main/res/layout/item_square_friend_answer.xml
+++ b/app/src/main/res/layout/item_square_friend_answer.xml
@@ -16,17 +16,33 @@
         android:translationZ="1dp"
         android:layout_marginTop="-8dp"
         android:layout_marginStart="-8dp"
-        app:layout_constraintTop_toTopOf="@id/civ_item_square_friend_answer_user_image"
-        app:layout_constraintStart_toStartOf="@id/civ_item_square_friend_answer_user_image"/>
+        app:layout_constraintTop_toTopOf="@id/cv_item_square_friend_answer_user_image"
+        app:layout_constraintStart_toStartOf="@id/cv_item_square_friend_answer_user_image"/>
 
-    <de.hdodenhof.circleimageview.CircleImageView
-        android:id="@+id/civ_item_square_friend_answer_user_image"
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/cv_item_square_friend_answer_user_image"
         android:layout_width="44dp"
         android:layout_height="44dp"
         android:layout_marginStart="4dp"
-        android:src="@drawable/img_temp_square_user_thumbnail"
+        android:clipToOutline="true"
+        app:cardCornerRadius="22dp"
+        app:strokeWidth="0dp"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"/>
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageView
+            android:id="@+id/iv_item_square_friend_answer_user_background"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scaleType="centerCrop" />
+
+        <ImageView
+            android:id="@+id/iv_item_square_friend_answer_user_image"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scaleType="fitCenter"
+            android:src="@drawable/img_temp_square_user_thumbnail" />
+    </com.google.android.material.card.MaterialCardView>
 
     <TextView
         android:id="@+id/tv_item_square_friend_answer_user_level"
@@ -40,9 +56,9 @@
         android:text="LV 1"
         android:textColor="@color/neutral"
         android:textSize="12sp"
-        app:layout_constraintEnd_toEndOf="@id/civ_item_square_friend_answer_user_image"
-        app:layout_constraintStart_toStartOf="@id/civ_item_square_friend_answer_user_image"
-        app:layout_constraintTop_toBottomOf="@id/civ_item_square_friend_answer_user_image" />
+        app:layout_constraintEnd_toEndOf="@id/cv_item_square_friend_answer_user_image"
+        app:layout_constraintStart_toStartOf="@id/cv_item_square_friend_answer_user_image"
+        app:layout_constraintTop_toBottomOf="@id/cv_item_square_friend_answer_user_image" />
 
     <TextView
         android:id="@+id/tv_item_square_friend_answer_user_name"
@@ -55,8 +71,8 @@
         android:textSize="14sp"
         android:fontFamily="@font/arita_semibold"
         android:layout_marginStart="12dp"
-        app:layout_constraintTop_toTopOf="@id/civ_item_square_friend_answer_user_image"
-        app:layout_constraintStart_toEndOf="@id/civ_item_square_friend_answer_user_image"/>
+        app:layout_constraintTop_toTopOf="@id/cv_item_square_friend_answer_user_image"
+        app:layout_constraintStart_toEndOf="@id/cv_item_square_friend_answer_user_image"/>
 
     <ImageView
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/item_square_friend_answer.xml
+++ b/app/src/main/res/layout/item_square_friend_answer.xml
@@ -75,8 +75,10 @@
         app:layout_constraintStart_toEndOf="@id/cv_item_square_friend_answer_user_image"/>
 
     <ImageView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:id="@+id/iv_item_square_friend_answer_symbol"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:scaleType="fitCenter"
         android:src="@drawable/ic_square_friend_answer_star"
         android:layout_marginStart="4dp"
         app:layout_constraintStart_toEndOf="@id/tv_item_square_friend_answer_user_name"

--- a/app/src/main/res/layout/item_square_friend_list.xml
+++ b/app/src/main/res/layout/item_square_friend_list.xml
@@ -11,15 +11,23 @@
         android:id="@+id/cv_item_friend_list_image"
         android:layout_width="144dp"
         android:layout_height="120dp"
+        android:clipToOutline="true"
         app:strokeWidth="0dp"
         app:cardCornerRadius="12dp"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintBottom_toBottomOf="parent">
         <ImageView
+            android:id="@+id/iv_item_friend_list_background"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scaleType="centerCrop" />
+
+        <ImageView
             android:id="@+id/iv_item_friend_list_image"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:scaleType="fitCenter"
             android:src="@drawable/default_turtle"/>
     </com.google.android.material.card.MaterialCardView>
 

--- a/app/src/main/res/layout/item_square_friend_pending_received_list.xml
+++ b/app/src/main/res/layout/item_square_friend_pending_received_list.xml
@@ -19,12 +19,14 @@
         app:layout_constraintBottom_toBottomOf="parent">
 
         <ImageView
+            android:id="@+id/iv_item_friend_pending_list_background"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:scaleType="centerCrop"
             android:src="@drawable/default_background" />
 
         <ImageView
+            android:id="@+id/iv_item_friend_pending_list_image"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:padding="8dp"

--- a/app/src/main/res/layout/item_square_friend_pending_sent_list.xml
+++ b/app/src/main/res/layout/item_square_friend_pending_sent_list.xml
@@ -19,12 +19,14 @@
         app:layout_constraintBottom_toBottomOf="parent">
 
         <ImageView
+            android:id="@+id/iv_item_friend_pending_sent_list_background"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:scaleType="centerCrop"
             android:src="@drawable/default_background" />
 
         <ImageView
+            android:id="@+id/iv_item_friend_pending_sent_list_image"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:padding="8dp"

--- a/app/src/main/res/layout/item_square_question_reply.xml
+++ b/app/src/main/res/layout/item_square_question_reply.xml
@@ -16,17 +16,33 @@
         android:translationZ="1dp"
         android:layout_marginTop="-8dp"
         android:layout_marginStart="-8dp"
-        app:layout_constraintTop_toTopOf="@id/civ_item_square_question_reply_user_image"
-        app:layout_constraintStart_toStartOf="@id/civ_item_square_question_reply_user_image"/>
+        app:layout_constraintTop_toTopOf="@id/cv_item_square_question_reply_user_image"
+        app:layout_constraintStart_toStartOf="@id/cv_item_square_question_reply_user_image"/>
 
-    <de.hdodenhof.circleimageview.CircleImageView
-        android:id="@+id/civ_item_square_question_reply_user_image"
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/cv_item_square_question_reply_user_image"
         android:layout_width="44dp"
         android:layout_height="44dp"
         android:layout_marginStart="4dp"
-        android:src="@drawable/img_temp_square_user_thumbnail"
+        android:clipToOutline="true"
+        app:cardCornerRadius="22dp"
+        app:strokeWidth="0dp"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"/>
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageView
+            android:id="@+id/iv_item_square_question_reply_user_background"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scaleType="centerCrop" />
+
+        <ImageView
+            android:id="@+id/iv_item_square_question_reply_user_image"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scaleType="fitCenter"
+            android:src="@drawable/img_temp_square_user_thumbnail" />
+    </com.google.android.material.card.MaterialCardView>
 
     <TextView
         android:id="@+id/tv_item_square_question_reply_user_level"
@@ -37,9 +53,9 @@
         android:textSize="12sp"
         android:fontFamily="@font/arita_medium"
         android:layout_marginTop="4dp"
-        app:layout_constraintTop_toBottomOf="@id/civ_item_square_question_reply_user_image"
-        app:layout_constraintStart_toStartOf="@id/civ_item_square_question_reply_user_image"
-        app:layout_constraintEnd_toEndOf="@id/civ_item_square_question_reply_user_image"/>
+        app:layout_constraintTop_toBottomOf="@id/cv_item_square_question_reply_user_image"
+        app:layout_constraintStart_toStartOf="@id/cv_item_square_question_reply_user_image"
+        app:layout_constraintEnd_toEndOf="@id/cv_item_square_question_reply_user_image"/>
 
     <ImageView
         android:id="@+id/iv_item_square_question_reply_symbol"
@@ -47,8 +63,8 @@
         android:layout_height="wrap_content"
         android:src="@drawable/ic_square_friend_answer_star"
         android:layout_marginStart="12dp"
-        app:layout_constraintTop_toTopOf="@id/civ_item_square_question_reply_user_image"
-        app:layout_constraintStart_toEndOf="@id/civ_item_square_question_reply_user_image"/>
+        app:layout_constraintTop_toTopOf="@id/cv_item_square_question_reply_user_image"
+        app:layout_constraintStart_toEndOf="@id/cv_item_square_question_reply_user_image"/>
 
     <ImageView
         android:id="@+id/iv_square_question_reply_report"

--- a/app/src/main/res/layout/item_square_question_reply.xml
+++ b/app/src/main/res/layout/item_square_question_reply.xml
@@ -59,8 +59,9 @@
 
     <ImageView
         android:id="@+id/iv_item_square_question_reply_symbol"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:scaleType="fitCenter"
         android:src="@drawable/ic_square_friend_answer_star"
         android:layout_marginStart="12dp"
         app:layout_constraintTop_toTopOf="@id/cv_item_square_question_reply_user_image"

--- a/app/src/test/java/com/egobook/app/store/data/ShopRepositoryTest.kt
+++ b/app/src/test/java/com/egobook/app/store/data/ShopRepositoryTest.kt
@@ -1,0 +1,59 @@
+package com.egobook.app.store.data
+
+import com.egobook.app.store.data.local.LocalShopDataSource
+import com.egobook.app.store.data.model.ItemStatus
+import com.egobook.app.store.data.model.ItemType
+import com.egobook.app.store.data.model.Price
+import com.egobook.app.store.data.network.RemoteShopDataSource
+import com.egobook.app.store.ui.CustomItem
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.coVerifyOrder
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ShopRepositoryTest {
+    private val local = mockk<LocalShopDataSource>(relaxed = true)
+    private val remote = mockk<RemoteShopDataSource>()
+    private val repository = ShopRepository(local, remote)
+    private val item = CustomItem(
+        id = "1",
+        type = ItemType.SKIN,
+        price = Price(0),
+        itemStatus = ItemStatus.PURCHASED
+    )
+
+    @Test
+    fun `successful equip confirms profile before reloading equipped items`() = runTest {
+        coEvery { remote.permanentEquipItem(item, true) } returns EquipState(true)
+        coEvery { remote.confirmProfile() } returns Unit
+        coEvery { remote.loadEquippedItems() } returns emptyList()
+
+        repository.equipItemPermanently(item, true)
+
+        coVerifyOrder {
+            remote.permanentEquipItem(item, true)
+            remote.confirmProfile()
+            remote.loadEquippedItems()
+        }
+        coVerify(exactly = 1) { remote.confirmProfile() }
+    }
+
+    @Test
+    fun `failed equip does not confirm or reload profile`() = runTest {
+        coEvery { remote.permanentEquipItem(item, true) } returns EquipState(false)
+
+        val failure = try {
+            repository.equipItemPermanently(item, true)
+            null
+        } catch (error: IllegalStateException) {
+            error
+        }
+        assertThat(failure).isNotNull()
+
+        coVerify(exactly = 0) { remote.confirmProfile() }
+        coVerify(exactly = 0) { remote.loadEquippedItems() }
+    }
+}

--- a/app/src/test/java/com/egobook/app/store/data/network/RemoteShopDataSourceTest.kt
+++ b/app/src/test/java/com/egobook/app/store/data/network/RemoteShopDataSourceTest.kt
@@ -1,0 +1,54 @@
+package com.egobook.app.store.data.network
+
+import com.egobook.app.store.data.PermanentEquipRequest
+import com.egobook.app.store.data.model.ItemStatus
+import com.egobook.app.store.data.model.ItemType
+import com.egobook.app.store.data.model.Price
+import com.egobook.app.store.ui.CustomItem
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import retrofit2.Retrofit
+
+class RemoteShopDataSourceTest {
+    private val apiService = mockk<ShopApiService>()
+    private val retrofit = mockk<Retrofit> {
+        every { create(ShopApiService::class.java) } returns apiService
+    }
+    private val dataSource = RemoteShopDataSource(retrofit)
+    private val item = CustomItem(
+        id = "1",
+        type = ItemType.SKIN,
+        price = Price(0),
+        itemStatus = ItemStatus.PURCHASED
+    )
+
+    @Test
+    fun `equip cancellation is propagated`() = runTest {
+        coEvery {
+            apiService.equipItemPermanently(PermanentEquipRequest(itemId = 1, isEquipped = true))
+        } throws CancellationException("cancelled")
+
+        val cancellation = try {
+            dataSource.permanentEquipItem(item, true)
+            null
+        } catch (error: CancellationException) {
+            error
+        }
+
+        assertThat(cancellation).isNotNull()
+    }
+
+    @Test
+    fun `ordinary equip exception becomes a failed state`() = runTest {
+        coEvery {
+            apiService.equipItemPermanently(PermanentEquipRequest(itemId = 1, isEquipped = true))
+        } throws IllegalStateException("network failure")
+
+        assertThat(dataSource.permanentEquipItem(item, true).isSuccess).isFalse()
+    }
+}

--- a/app/src/test/java/com/egobook/app/ui/square/LevelBadgeMapperTest.kt
+++ b/app/src/test/java/com/egobook/app/ui/square/LevelBadgeMapperTest.kt
@@ -1,0 +1,28 @@
+package com.egobook.app.ui.square
+
+import com.egobook.app.R
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class LevelBadgeMapperTest {
+    @Test
+    fun `level thresholds map to existing badge drawables`() {
+        assertThat(levelBadgeDrawable(0)).isEqualTo(R.drawable.level_type_1)
+        assertThat(levelBadgeDrawable(100)).isEqualTo(R.drawable.level_type_2)
+        assertThat(levelBadgeDrawable(300)).isEqualTo(R.drawable.level_type_3)
+        assertThat(levelBadgeDrawable(500)).isEqualTo(R.drawable.level_type_4)
+        assertThat(levelBadgeDrawable(700)).isEqualTo(R.drawable.level_type_5)
+        assertThat(levelBadgeDrawable(1000)).isEqualTo(R.drawable.level_type_6)
+        assertThat(levelBadgeDrawable(1300)).isEqualTo(R.drawable.level_type_7)
+        assertThat(levelBadgeDrawable(1500)).isEqualTo(R.drawable.level_type_8)
+    }
+
+    @Test
+    fun `levels outside the shared domain range are rejected`() {
+        assertThatThrownBy { levelBadgeDrawable(-1) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+        assertThatThrownBy { levelBadgeDrawable(1501) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+}

--- a/app/src/test/java/com/egobook/app/ui/square/ProfileImageMappingTest.kt
+++ b/app/src/test/java/com/egobook/app/ui/square/ProfileImageMappingTest.kt
@@ -1,6 +1,7 @@
 package com.egobook.app.ui.square
 
 import com.egobook.app.data.model.square.friend.FriendResponse
+import com.egobook.app.data.model.square.friend.FriendRequestResponse
 import com.egobook.app.data.model.square.friend.SearchUserResponse
 import com.egobook.app.data.model.square.friend.toDomain
 import com.egobook.app.data.model.square.question.UserTodayQuestionAnswerItemResponse
@@ -47,8 +48,26 @@ class ProfileImageMappingTest {
             nickname = "friend",
             content = "answer",
             createdAt = "2026-08-06T00:00:00Z",
+            level = 321L,
             turtleImageUrl = TURTLE_IMAGE_URL,
             backgroundImageUrl = BACKGROUND_IMAGE_URL
+        ).toDomain().toPresentation()
+
+        assertThat(model.turtleImageUrl).isEqualTo(TURTLE_IMAGE_URL)
+        assertThat(model.backgroundImageUrl).isEqualTo(BACKGROUND_IMAGE_URL)
+        assertThat(model.level).isEqualTo(321L)
+    }
+
+    @Test
+    fun `pending friend profile image urls are preserved through presentation mapping`() {
+        val model = FriendRequestResponse(
+            requestId = 1L,
+            userId = 2L,
+            nickname = "friend",
+            level = 10L,
+            turtleImageUrl = TURTLE_IMAGE_URL,
+            backgroundImageUrl = BACKGROUND_IMAGE_URL,
+            requestedAt = "2026-08-06T00:00:00Z"
         ).toDomain().toPresentation()
 
         assertThat(model.turtleImageUrl).isEqualTo(TURTLE_IMAGE_URL)

--- a/app/src/test/java/com/egobook/app/ui/square/ProfileImageMappingTest.kt
+++ b/app/src/test/java/com/egobook/app/ui/square/ProfileImageMappingTest.kt
@@ -1,0 +1,74 @@
+package com.egobook.app.ui.square
+
+import com.egobook.app.data.model.square.friend.FriendResponse
+import com.egobook.app.data.model.square.friend.SearchUserResponse
+import com.egobook.app.data.model.square.friend.toDomain
+import com.egobook.app.data.model.square.question.UserTodayQuestionAnswerItemResponse
+import com.egobook.app.data.model.square.question.toDomain
+import com.egobook.app.ui.square.model.friend.toPresentation
+import com.egobook.app.ui.square.model.question.toPresentation
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ProfileImageMappingTest {
+    @Test
+    fun `friend profile image urls are preserved through presentation mapping`() {
+        val model = FriendResponse(
+            id = 1L,
+            name = "friend",
+            level = 10L,
+            turtleImageUrl = TURTLE_IMAGE_URL,
+            backgroundImageUrl = BACKGROUND_IMAGE_URL
+        ).toDomain().toPresentation()
+
+        assertThat(model.turtleImageUrl).isEqualTo(TURTLE_IMAGE_URL)
+        assertThat(model.backgroundImageUrl).isEqualTo(BACKGROUND_IMAGE_URL)
+    }
+
+    @Test
+    fun `searched user profile image urls are preserved through presentation mapping`() {
+        val model = SearchUserResponse(
+            userId = 1L,
+            nickname = "friend",
+            level = 10L,
+            turtleImageUrl = TURTLE_IMAGE_URL,
+            backgroundImageUrl = BACKGROUND_IMAGE_URL
+        ).toDomain().toPresentation()
+
+        assertThat(model.turtleImageUrl).isEqualTo(TURTLE_IMAGE_URL)
+        assertThat(model.backgroundImageUrl).isEqualTo(BACKGROUND_IMAGE_URL)
+    }
+
+    @Test
+    fun `question answer profile image urls are preserved through presentation mapping`() {
+        val model = UserTodayQuestionAnswerItemResponse(
+            answerId = 1L,
+            userId = 2L,
+            nickname = "friend",
+            content = "answer",
+            createdAt = "2026-08-06T00:00:00Z",
+            turtleImageUrl = TURTLE_IMAGE_URL,
+            backgroundImageUrl = BACKGROUND_IMAGE_URL
+        ).toDomain().toPresentation()
+
+        assertThat(model.turtleImageUrl).isEqualTo(TURTLE_IMAGE_URL)
+        assertThat(model.backgroundImageUrl).isEqualTo(BACKGROUND_IMAGE_URL)
+    }
+
+    @Test
+    fun `missing profile image urls remain null through presentation mapping`() {
+        val model = FriendResponse(
+            id = 1L,
+            name = "friend",
+            level = 10L
+        ).toDomain().toPresentation()
+
+        assertThat(model.turtleImageUrl).isNull()
+        assertThat(model.backgroundImageUrl).isNull()
+    }
+
+    private companion object {
+        const val TURTLE_IMAGE_URL = "https://example.com/turtle.png"
+        const val BACKGROUND_IMAGE_URL = "https://example.com/background.png"
+    }
+}

--- a/app/src/test/java/com/egobook/app/ui/square/ProfileImageMappingTest.kt
+++ b/app/src/test/java/com/egobook/app/ui/square/ProfileImageMappingTest.kt
@@ -49,6 +49,7 @@ class ProfileImageMappingTest {
             content = "answer",
             createdAt = "2026-08-06T00:00:00Z",
             level = 321L,
+            topAbilityName = "긍정사고",
             turtleImageUrl = TURTLE_IMAGE_URL,
             backgroundImageUrl = BACKGROUND_IMAGE_URL
         ).toDomain().toPresentation()
@@ -56,6 +57,7 @@ class ProfileImageMappingTest {
         assertThat(model.turtleImageUrl).isEqualTo(TURTLE_IMAGE_URL)
         assertThat(model.backgroundImageUrl).isEqualTo(BACKGROUND_IMAGE_URL)
         assertThat(model.level).isEqualTo(321L)
+        assertThat(model.topAbilityName).isEqualTo("긍정사고")
     }
 
     @Test

--- a/app/src/test/java/com/egobook/app/ui/square/ProfileImagePlacementTest.kt
+++ b/app/src/test/java/com/egobook/app/ui/square/ProfileImagePlacementTest.kt
@@ -29,12 +29,12 @@ class ProfileImagePlacementTest {
     }
 
     @Test
-    fun `plaza turtle is scaled from fit center and aligned start bottom`() {
+    fun `plaza turtle is scaled from original and aligned start bottom`() {
         val result = calculateProfileImageTransform(100, 100, 200, 100, ProfileImagePlacement.PLAZA_TURTLE)
 
-        assertThat(result.scale).isCloseTo(0.15f, offset(0.0001f))
+        assertThat(result.scale).isCloseTo(0.3f, offset(0.0001f))
         assertThat(result.translateX).isCloseTo(0f, offset(0.0001f))
-        assertThat(result.translateY).isCloseTo(85f, offset(0.0001f))
+        assertThat(result.translateY).isCloseTo(70f, offset(0.0001f))
     }
 
     @Test
@@ -47,12 +47,12 @@ class ProfileImagePlacementTest {
     }
 
     @Test
-    fun `friend turtle keeps fit size and aligns start bottom`() {
+    fun `friend turtle keeps original size and aligns start bottom`() {
         val result = calculateProfileImageTransform(100, 100, 200, 100, ProfileImagePlacement.FRIEND_TURTLE)
 
-        assertThat(result.scale).isCloseTo(0.5f, offset(0.0001f))
+        assertThat(result.scale).isCloseTo(1f, offset(0.0001f))
         assertThat(result.translateX).isCloseTo(0f, offset(0.0001f))
-        assertThat(result.translateY).isCloseTo(50f, offset(0.0001f))
+        assertThat(result.translateY).isCloseTo(0f, offset(0.0001f))
     }
 
     @Test

--- a/app/src/test/java/com/egobook/app/ui/square/ProfileImagePlacementTest.kt
+++ b/app/src/test/java/com/egobook/app/ui/square/ProfileImagePlacementTest.kt
@@ -18,11 +18,11 @@ class ProfileImagePlacementTest {
     }
 
     @Test
-    fun `friend turtle centers a larger head at eighty five percent of frame width`() {
+    fun `friend turtle centers its head at seventy percent of frame width`() {
         val result = calculateProfileImageTransform(100, 100, 304, 197, ProfileImagePlacement.FRIEND_TURTLE)
 
         assertThat(304f * TURTLE_HEAD_WIDTH_FRACTION * result.scale)
-            .isCloseTo(85f, offset(0.01f))
+            .isCloseTo(70f, offset(0.01f))
         assertThat(304f * TURTLE_HEAD_CENTER_X_FRACTION * result.scale + result.translateX)
             .isCloseTo(50f, offset(0.01f))
         assertThat(197f * TURTLE_HEAD_CENTER_Y_FRACTION * result.scale + result.translateY)

--- a/app/src/test/java/com/egobook/app/ui/square/ProfileImagePlacementTest.kt
+++ b/app/src/test/java/com/egobook/app/ui/square/ProfileImagePlacementTest.kt
@@ -1,0 +1,66 @@
+package com.egobook.app.ui.square
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Offset.offset
+import org.junit.jupiter.api.Test
+
+class ProfileImagePlacementTest {
+    @Test
+    fun `plaza profile placement follows design ratios`() {
+        assertThat(ProfileImagePlacement.PLAZA_TURTLE.scale).isEqualTo(0.3f)
+        assertThat(ProfileImagePlacement.PLAZA_TURTLE.horizontal).isEqualTo(ProfileAlignment.START)
+        assertThat(ProfileImagePlacement.PLAZA_TURTLE.vertical).isEqualTo(ProfileAlignment.END)
+
+        assertThat(ProfileImagePlacement.PLAZA_BACKGROUND.scale).isEqualTo(0.1f)
+        assertThat(ProfileImagePlacement.PLAZA_BACKGROUND.horizontal).isEqualTo(ProfileAlignment.CENTER)
+        assertThat(ProfileImagePlacement.PLAZA_BACKGROUND.vertical).isEqualTo(ProfileAlignment.CENTER)
+    }
+
+    @Test
+    fun `friend profile placement follows design ratios`() {
+        assertThat(ProfileImagePlacement.FRIEND_TURTLE.scale).isEqualTo(1f)
+        assertThat(ProfileImagePlacement.FRIEND_TURTLE.horizontal).isEqualTo(ProfileAlignment.START)
+        assertThat(ProfileImagePlacement.FRIEND_TURTLE.vertical).isEqualTo(ProfileAlignment.END)
+
+        assertThat(ProfileImagePlacement.FRIEND_BACKGROUND.scale).isEqualTo(0.5f)
+        assertThat(ProfileImagePlacement.FRIEND_BACKGROUND.horizontal).isEqualTo(ProfileAlignment.CENTER)
+        assertThat(ProfileImagePlacement.FRIEND_BACKGROUND.vertical).isEqualTo(ProfileAlignment.CENTER)
+        assertThat(ProfileImagePlacement.FRIEND_BACKGROUND.verticalOffsetFraction).isEqualTo(-0.131f)
+    }
+
+    @Test
+    fun `plaza turtle is scaled from fit center and aligned start bottom`() {
+        val result = calculateProfileImageTransform(100, 100, 200, 100, ProfileImagePlacement.PLAZA_TURTLE)
+
+        assertThat(result.scale).isCloseTo(0.15f, offset(0.0001f))
+        assertThat(result.translateX).isCloseTo(0f, offset(0.0001f))
+        assertThat(result.translateY).isCloseTo(85f, offset(0.0001f))
+    }
+
+    @Test
+    fun `plaza background is scaled and centered`() {
+        val result = calculateProfileImageTransform(100, 100, 50, 100, ProfileImagePlacement.PLAZA_BACKGROUND)
+
+        assertThat(result.scale).isCloseTo(0.1f, offset(0.0001f))
+        assertThat(result.translateX).isCloseTo(47.5f, offset(0.0001f))
+        assertThat(result.translateY).isCloseTo(45f, offset(0.0001f))
+    }
+
+    @Test
+    fun `friend turtle keeps fit size and aligns start bottom`() {
+        val result = calculateProfileImageTransform(100, 100, 200, 100, ProfileImagePlacement.FRIEND_TURTLE)
+
+        assertThat(result.scale).isCloseTo(0.5f, offset(0.0001f))
+        assertThat(result.translateX).isCloseTo(0f, offset(0.0001f))
+        assertThat(result.translateY).isCloseTo(50f, offset(0.0001f))
+    }
+
+    @Test
+    fun `friend background centers then offsets by thirteen point one percent of frame height`() {
+        val result = calculateProfileImageTransform(200, 100, 100, 100, ProfileImagePlacement.FRIEND_BACKGROUND)
+
+        assertThat(result.scale).isCloseTo(0.5f, offset(0.0001f))
+        assertThat(result.translateX).isCloseTo(75f, offset(0.0001f))
+        assertThat(result.translateY).isCloseTo(11.9f, offset(0.0001f))
+    }
+}

--- a/app/src/test/java/com/egobook/app/ui/square/ProfileImagePlacementTest.kt
+++ b/app/src/test/java/com/egobook/app/ui/square/ProfileImagePlacementTest.kt
@@ -18,15 +18,15 @@ class ProfileImagePlacementTest {
     }
 
     @Test
-    fun `friend turtle centers its head at seventy percent of frame width`() {
+    fun `friend turtle places a smaller head toward the lower left`() {
         val result = calculateProfileImageTransform(100, 100, 304, 197, ProfileImagePlacement.FRIEND_TURTLE)
 
         assertThat(304f * TURTLE_HEAD_WIDTH_FRACTION * result.scale)
-            .isCloseTo(70f, offset(0.01f))
+            .isCloseTo(60f, offset(0.01f))
         assertThat(304f * TURTLE_HEAD_CENTER_X_FRACTION * result.scale + result.translateX)
-            .isCloseTo(50f, offset(0.01f))
+            .isCloseTo(38f, offset(0.01f))
         assertThat(197f * TURTLE_HEAD_CENTER_Y_FRACTION * result.scale + result.translateY)
-            .isCloseTo(50f, offset(0.01f))
+            .isCloseTo(62f, offset(0.01f))
     }
 
     @Test

--- a/app/src/test/java/com/egobook/app/ui/square/ProfileImagePlacementTest.kt
+++ b/app/src/test/java/com/egobook/app/ui/square/ProfileImagePlacementTest.kt
@@ -6,61 +6,44 @@ import org.junit.jupiter.api.Test
 
 class ProfileImagePlacementTest {
     @Test
-    fun `plaza profile placement follows design ratios`() {
-        assertThat(ProfileImagePlacement.PLAZA_TURTLE.scale).isEqualTo(0.3f)
-        assertThat(ProfileImagePlacement.PLAZA_TURTLE.horizontal).isEqualTo(ProfileAlignment.START)
-        assertThat(ProfileImagePlacement.PLAZA_TURTLE.vertical).isEqualTo(ProfileAlignment.END)
+    fun `plaza turtle centers its head at sixty five percent of frame width`() {
+        val result = calculateProfileImageTransform(100, 100, 304, 197, ProfileImagePlacement.PLAZA_TURTLE)
 
-        assertThat(ProfileImagePlacement.PLAZA_BACKGROUND.scale).isEqualTo(0.1f)
-        assertThat(ProfileImagePlacement.PLAZA_BACKGROUND.horizontal).isEqualTo(ProfileAlignment.CENTER)
-        assertThat(ProfileImagePlacement.PLAZA_BACKGROUND.vertical).isEqualTo(ProfileAlignment.CENTER)
+        assertThat(304f * TURTLE_HEAD_WIDTH_FRACTION * result.scale)
+            .isCloseTo(65f, offset(0.01f))
+        assertThat(304f * TURTLE_HEAD_CENTER_X_FRACTION * result.scale + result.translateX)
+            .isCloseTo(50f, offset(0.01f))
+        assertThat(197f * TURTLE_HEAD_CENTER_Y_FRACTION * result.scale + result.translateY)
+            .isCloseTo(50f, offset(0.01f))
     }
 
     @Test
-    fun `friend profile placement follows design ratios`() {
-        assertThat(ProfileImagePlacement.FRIEND_TURTLE.scale).isEqualTo(1f)
-        assertThat(ProfileImagePlacement.FRIEND_TURTLE.horizontal).isEqualTo(ProfileAlignment.START)
-        assertThat(ProfileImagePlacement.FRIEND_TURTLE.vertical).isEqualTo(ProfileAlignment.END)
+    fun `friend turtle centers a larger head at eighty five percent of frame width`() {
+        val result = calculateProfileImageTransform(100, 100, 304, 197, ProfileImagePlacement.FRIEND_TURTLE)
 
-        assertThat(ProfileImagePlacement.FRIEND_BACKGROUND.scale).isEqualTo(0.5f)
-        assertThat(ProfileImagePlacement.FRIEND_BACKGROUND.horizontal).isEqualTo(ProfileAlignment.CENTER)
-        assertThat(ProfileImagePlacement.FRIEND_BACKGROUND.vertical).isEqualTo(ProfileAlignment.CENTER)
-        assertThat(ProfileImagePlacement.FRIEND_BACKGROUND.verticalOffsetFraction).isEqualTo(-0.131f)
+        assertThat(304f * TURTLE_HEAD_WIDTH_FRACTION * result.scale)
+            .isCloseTo(85f, offset(0.01f))
+        assertThat(304f * TURTLE_HEAD_CENTER_X_FRACTION * result.scale + result.translateX)
+            .isCloseTo(50f, offset(0.01f))
+        assertThat(197f * TURTLE_HEAD_CENTER_Y_FRACTION * result.scale + result.translateY)
+            .isCloseTo(50f, offset(0.01f))
     }
 
     @Test
-    fun `plaza turtle is scaled from original and aligned start bottom`() {
-        val result = calculateProfileImageTransform(100, 100, 200, 100, ProfileImagePlacement.PLAZA_TURTLE)
+    fun `plaza background center crops to fill the frame`() {
+        val result = calculateProfileImageTransform(100, 100, 500, 1000, ProfileImagePlacement.PLAZA_BACKGROUND)
 
-        assertThat(result.scale).isCloseTo(0.3f, offset(0.0001f))
-        assertThat(result.translateX).isCloseTo(0f, offset(0.0001f))
-        assertThat(result.translateY).isCloseTo(70f, offset(0.0001f))
+        assertThat(result.scale).isCloseTo(0.2f, offset(0.001f))
+        assertThat(result.translateX).isCloseTo(0f, offset(0.001f))
+        assertThat(result.translateY).isCloseTo(-50f, offset(0.001f))
     }
 
     @Test
-    fun `plaza background is scaled and centered`() {
-        val result = calculateProfileImageTransform(100, 100, 50, 100, ProfileImagePlacement.PLAZA_BACKGROUND)
+    fun `friend background center crops then moves up thirteen point one percent`() {
+        val result = calculateProfileImageTransform(100, 100, 500, 1000, ProfileImagePlacement.FRIEND_BACKGROUND)
 
-        assertThat(result.scale).isCloseTo(0.1f, offset(0.0001f))
-        assertThat(result.translateX).isCloseTo(47.5f, offset(0.0001f))
-        assertThat(result.translateY).isCloseTo(45f, offset(0.0001f))
-    }
-
-    @Test
-    fun `friend turtle keeps original size and aligns start bottom`() {
-        val result = calculateProfileImageTransform(100, 100, 200, 100, ProfileImagePlacement.FRIEND_TURTLE)
-
-        assertThat(result.scale).isCloseTo(1f, offset(0.0001f))
-        assertThat(result.translateX).isCloseTo(0f, offset(0.0001f))
-        assertThat(result.translateY).isCloseTo(0f, offset(0.0001f))
-    }
-
-    @Test
-    fun `friend background centers then offsets by thirteen point one percent of frame height`() {
-        val result = calculateProfileImageTransform(200, 100, 100, 100, ProfileImagePlacement.FRIEND_BACKGROUND)
-
-        assertThat(result.scale).isCloseTo(0.5f, offset(0.0001f))
-        assertThat(result.translateX).isCloseTo(75f, offset(0.0001f))
-        assertThat(result.translateY).isCloseTo(11.9f, offset(0.0001f))
+        assertThat(result.scale).isCloseTo(0.2f, offset(0.001f))
+        assertThat(result.translateX).isCloseTo(0f, offset(0.001f))
+        assertThat(result.translateY).isCloseTo(-63.1f, offset(0.001f))
     }
 }

--- a/app/src/test/java/com/egobook/app/ui/square/ProfileImageSourcePolicyTest.kt
+++ b/app/src/test/java/com/egobook/app/ui/square/ProfileImageSourcePolicyTest.kt
@@ -11,4 +11,12 @@ class ProfileImageSourcePolicyTest {
         assertThat(hasRemoteProfileImage("   ")).isFalse()
         assertThat(hasRemoteProfileImage("https://example.com/profile.png")).isTrue()
     }
+
+    @Test
+    fun `only the default turtle is mirrored horizontally`() {
+        assertThat(profileTurtleScaleX(null)).isEqualTo(-1f)
+        assertThat(profileTurtleScaleX("https://example.com/profile.png")).isEqualTo(1f)
+        assertThat(profileTurtleScaleX("https://example.com/profile.png", isFallbackDisplayed = true))
+            .isEqualTo(-1f)
+    }
 }

--- a/app/src/test/java/com/egobook/app/ui/square/ProfileImageSourcePolicyTest.kt
+++ b/app/src/test/java/com/egobook/app/ui/square/ProfileImageSourcePolicyTest.kt
@@ -1,0 +1,14 @@
+package com.egobook.app.ui.square
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ProfileImageSourcePolicyTest {
+    @Test
+    fun `custom placement is applied only to a remote profile image`() {
+        assertThat(hasRemoteProfileImage(null)).isFalse()
+        assertThat(hasRemoteProfileImage("")).isFalse()
+        assertThat(hasRemoteProfileImage("   ")).isFalse()
+        assertThat(hasRemoteProfileImage("https://example.com/profile.png")).isTrue()
+    }
+}

--- a/app/src/test/java/com/egobook/app/ui/square/ProfileImageSourcePolicyTest.kt
+++ b/app/src/test/java/com/egobook/app/ui/square/ProfileImageSourcePolicyTest.kt
@@ -13,10 +13,13 @@ class ProfileImageSourcePolicyTest {
     }
 
     @Test
-    fun `only the default turtle is mirrored horizontally`() {
-        assertThat(profileTurtleScaleX(null)).isEqualTo(-1f)
-        assertThat(profileTurtleScaleX("https://example.com/profile.png")).isEqualTo(1f)
-        assertThat(profileTurtleScaleX("https://example.com/profile.png", isFallbackDisplayed = true))
+    fun `only the plaza default turtle is mirrored horizontally`() {
+        assertThat(profileTurtleScaleX(null, mirrorFallback = true)).isEqualTo(-1f)
+        assertThat(profileTurtleScaleX(null, mirrorFallback = false)).isEqualTo(1f)
+        assertThat(profileTurtleScaleX("https://example.com/profile.png", mirrorFallback = true)).isEqualTo(1f)
+        assertThat(profileTurtleScaleX("https://example.com/profile.png", mirrorFallback = true, isFallbackDisplayed = true))
             .isEqualTo(-1f)
+        assertThat(profileTurtleScaleX("https://example.com/profile.png", mirrorFallback = false, isFallbackDisplayed = true))
+            .isEqualTo(1f)
     }
 }

--- a/app/src/test/java/com/egobook/app/ui/square/TendencyIconMapperTest.kt
+++ b/app/src/test/java/com/egobook/app/ui/square/TendencyIconMapperTest.kt
@@ -11,6 +11,7 @@ class TendencyIconMapperTest {
         assertThat(tendencyIconDrawable("공감성")).isEqualTo(R.drawable.ic_radar_heart)
         assertThat(tendencyIconDrawable("자존감")).isEqualTo(R.drawable.ic_radar_diamond)
         assertThat(tendencyIconDrawable("성실성")).isEqualTo(R.drawable.ic_radar_clover)
+        assertThat(tendencyIconDrawable("성실함")).isEqualTo(R.drawable.ic_radar_clover)
         assertThat(tendencyIconDrawable("긍정사고")).isEqualTo(R.drawable.ic_radar_sun)
         assertThat(tendencyIconDrawable("감정조절")).isEqualTo(R.drawable.ic_radar_star)
     }

--- a/app/src/test/java/com/egobook/app/ui/square/TendencyIconMapperTest.kt
+++ b/app/src/test/java/com/egobook/app/ui/square/TendencyIconMapperTest.kt
@@ -1,0 +1,35 @@
+package com.egobook.app.ui.square
+
+import com.egobook.app.R
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.Locale
+
+class TendencyIconMapperTest {
+    @Test
+    fun `question ability names map to radar icons`() {
+        assertThat(tendencyIconDrawable("공감성")).isEqualTo(R.drawable.ic_radar_heart)
+        assertThat(tendencyIconDrawable("자존감")).isEqualTo(R.drawable.ic_radar_diamond)
+        assertThat(tendencyIconDrawable("성실성")).isEqualTo(R.drawable.ic_radar_clover)
+        assertThat(tendencyIconDrawable("긍정사고")).isEqualTo(R.drawable.ic_radar_sun)
+        assertThat(tendencyIconDrawable("감정조절")).isEqualTo(R.drawable.ic_radar_star)
+    }
+
+    @Test
+    fun `enum codes and unknown values have stable mappings`() {
+        assertThat(tendencyIconDrawable("POSITIVE_THINKING")).isEqualTo(R.drawable.ic_radar_sun)
+        assertThat(tendencyIconDrawable(null)).isEqualTo(R.drawable.ic_square_friend_answer_star)
+        assertThat(tendencyIconDrawable("unknown")).isEqualTo(R.drawable.ic_square_friend_answer_star)
+    }
+
+    @Test
+    fun `lowercase enum code mapping does not depend on device locale`() {
+        val previousLocale = Locale.getDefault()
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr"))
+            assertThat(tendencyIconDrawable("diligence")).isEqualTo(R.drawable.ic_radar_clover)
+        } finally {
+            Locale.setDefault(previousLocale)
+        }
+    }
+}


### PR DESCRIPTION
- 광장 질문 답변 프로필 이미지, 레벨, 성향 연동
- 친구 목록, 검색, 신청 프로필 이미지 및 레벨 연동
- 기본 프로필 이미지 처리
- 프로필 생성 API 연동

Closes #109

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 친구, 친구 요청, 검색 사용자 및 질문 답변에 거북이·배경 프로필 이미지를 표시합니다.
  * 프로필 이미지 배치와 기본 이미지 대체 처리가 개선되었습니다.
  * 사용자 레벨 배지와 주요 능력 아이콘을 표시합니다.
  * 아이템 영구 장착 후 프로필 정보를 확인하고 장착 상태를 갱신합니다.

* **버그 수정**
  * 프로필 이미지가 없거나 로드에 실패한 경우에도 적절한 기본 이미지가 표시됩니다.
  * 영구 장착 실패 시 후속 프로필 확인 및 상태 갱신을 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->