### PR TITLE
✨Feat - 광장 편지 전송 취소하기 버튼 추가

### DIFF
--- a/app/src/main/java/com/egobook/app/data/repository/LetterRepositoryImpl.kt
+++ b/app/src/main/java/com/egobook/app/data/repository/LetterRepositoryImpl.kt
@@ -24,6 +24,7 @@ import com.egobook.app.domain.model.square.letter.SentLetterItem
 import com.egobook.app.domain.model.square.letter.SentLetterWithReply
 import com.egobook.app.domain.repository.LetterRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.CancellationException
 import javax.inject.Inject
 
 class LetterRepositoryImpl @Inject constructor(
@@ -48,6 +49,8 @@ class LetterRepositoryImpl @Inject constructor(
         } else {
             Result.failure(Exception("Error: ${response.code()}"))
         }
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         Result.failure(e)
     }

--- a/app/src/main/java/com/egobook/app/ui/square/view/DetectAbusiveContentLoadingDialog.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/view/DetectAbusiveContentLoadingDialog.kt
@@ -21,9 +21,14 @@ class DetectAbusiveContentLoadingDialog: DialogFragment(R.layout.dialog_detect_a
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding = DialogDetectAbusiveContentLoadingBinding.bind(view)
+        binding.btnDetectAbusiveContentLoadingCancel.setOnClickListener {
+            parentFragmentManager.setFragmentResult(CANCEL_REQUEST_KEY, Bundle.EMPTY)
+            dismiss()
+        }
     }
 
     companion object {
         const val TAG = "DetectAbusiveContentLoadingDialog"
+        const val CANCEL_REQUEST_KEY = "detectAbusiveContentCancel"
     }
 }

--- a/app/src/main/java/com/egobook/app/ui/square/view/LetterReplyFragment.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/view/LetterReplyFragment.kt
@@ -53,6 +53,13 @@ class LetterReplyFragment : Fragment(R.layout.fragment_letter_reply) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding = FragmentLetterReplyBinding.bind(view)
+        childFragmentManager.setFragmentResultListener(
+            DetectAbusiveContentLoadingDialog.CANCEL_REQUEST_KEY,
+            viewLifecycleOwner
+        ) { _, _ ->
+            viewModel.cancelDetectAbusiveContent()
+            hideLoadingDialog()
+        }
         fetchData()
         initViews()
         initListeners()
@@ -285,7 +292,10 @@ class LetterReplyFragment : Fragment(R.layout.fragment_letter_reply) {
     }
 
     private fun hideLoadingDialog() {
-        loadingDialog?.dismiss()
+        val displayedDialog = loadingDialog
+            ?: childFragmentManager.findFragmentByTag(DetectAbusiveContentLoadingDialog.TAG)
+                as? DetectAbusiveContentLoadingDialog
+        displayedDialog?.dismiss()
         loadingDialog = null
         removeScreenBlur()
     }

--- a/app/src/main/java/com/egobook/app/ui/square/view/LetterSendDialog.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/view/LetterSendDialog.kt
@@ -167,6 +167,7 @@ class LetterSendDialog(private val mode: LetterMode, private val friendInfo: Fri
         isSending = false
         binding.btnLetterSend.isEnabled = true
         binding.root.alpha = 1.0f
+        dismiss()
     }
 
     private fun hideLoadingDialog() {

--- a/app/src/main/java/com/egobook/app/ui/square/view/LetterSendDialog.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/view/LetterSendDialog.kt
@@ -41,6 +41,10 @@ class LetterSendDialog(private val mode: LetterMode, private val friendInfo: Fri
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding = DialogLetterSendBinding.bind(view)
+        parentFragmentManager.setFragmentResultListener(
+            DetectAbusiveContentLoadingDialog.CANCEL_REQUEST_KEY,
+            viewLifecycleOwner
+        ) { _, _ -> cancelAbusiveContentCheck() }
         initViews()
         initListeners()
         initObservers()
@@ -157,8 +161,19 @@ class LetterSendDialog(private val mode: LetterMode, private val friendInfo: Fri
         }
     }
 
+    private fun cancelAbusiveContentCheck() {
+        viewModel.cancelDetectAbusiveContent()
+        hideLoadingDialog()
+        isSending = false
+        binding.btnLetterSend.isEnabled = true
+        binding.root.alpha = 1.0f
+    }
+
     private fun hideLoadingDialog() {
-        loadingDialog?.dismiss()
+        val displayedDialog = loadingDialog
+            ?: parentFragmentManager.findFragmentByTag(DetectAbusiveContentLoadingDialog.TAG)
+                as? DetectAbusiveContentLoadingDialog
+        displayedDialog?.dismiss()
         loadingDialog = null
         removeScreenBlur()
     }

--- a/app/src/main/java/com/egobook/app/ui/square/viewmodel/LetterViewModel.kt
+++ b/app/src/main/java/com/egobook/app/ui/square/viewmodel/LetterViewModel.kt
@@ -47,6 +47,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -124,9 +125,11 @@ class LetterViewModel @Inject constructor(
 
     private val _detectAbusiveContentResult = MutableSharedFlow<UiState<AbusiveContentModel>>()
     val detectAbusiveContentResult = _detectAbusiveContentResult.asSharedFlow()
+    private var detectAbusiveContentJob: Job? = null
 
     fun detectAbusiveContent(text: String) {
-        viewModelScope.launch {
+        detectAbusiveContentJob?.cancel()
+        detectAbusiveContentJob = viewModelScope.launch {
             _detectAbusiveContentResult.emit(UiState.Loading)
             detectAbusiveContentUseCase(text = text).onSuccess { domain ->
                 _detectAbusiveContentResult.emit(UiState.Success(domain.toPresentation()))
@@ -134,6 +137,11 @@ class LetterViewModel @Inject constructor(
                 _detectAbusiveContentResult.emit(UiState.Failure(error.message))
             }
         }
+    }
+
+    fun cancelDetectAbusiveContent() {
+        detectAbusiveContentJob?.cancel()
+        detectAbusiveContentJob = null
     }
 
     private val _arrivedPendingLetterResult = MutableStateFlow<UiState<ArrivedPendingLetterModel>>(UiState.Idle) // stateflow vs sharedflow

--- a/app/src/main/res/layout/dialog_detect_abusive_content_loading.xml
+++ b/app/src/main/res/layout/dialog_detect_abusive_content_loading.xml
@@ -39,6 +39,7 @@
     </com.google.android.material.card.MaterialCardView>
 
     <TextView
+        android:id="@+id/tv_detect_abusive_content_loading_description"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="기분 좋은 소통을 할 수 있도록\n도와드릴게요"
@@ -52,5 +53,22 @@
         app:layout_constraintTop_toBottomOf="@id/cv_detect_abusive_loading"
         app:layout_constraintStart_toStartOf="@id/cv_detect_abusive_loading"
         app:layout_constraintEnd_toEndOf="@id/cv_detect_abusive_loading"/>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btn_detect_abusive_content_loading_cancel"
+        android:layout_width="200dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:backgroundTint="@color/grey_light"
+        android:fontFamily="@font/arita_semibold"
+        android:insetTop="0dp"
+        android:insetBottom="0dp"
+        android:text="취소하기"
+        android:textColor="@color/neutral"
+        android:textSize="12sp"
+        app:cornerRadius="4dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_detect_abusive_content_loading_description" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/test/java/com/egobook/app/data/repository/LetterRepositoryImplTest.kt
+++ b/app/src/test/java/com/egobook/app/data/repository/LetterRepositoryImplTest.kt
@@ -1,0 +1,33 @@
+package com.egobook.app.data.repository
+
+import com.egobook.app.data.api.AIApiService
+import com.egobook.app.data.api.LetterApiService
+import com.egobook.app.data.model.square.letter.DetectAbusiveContentRequest
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class LetterRepositoryImplTest {
+    private val letterApiService = mockk<LetterApiService>()
+    private val aiApiService = mockk<AIApiService>()
+    private val repository = LetterRepositoryImpl(letterApiService, aiApiService)
+
+    @Test
+    fun `abusive content analysis cancellation is propagated`() = runTest {
+        coEvery {
+            aiApiService.detectAbusiveContent(DetectAbusiveContentRequest("content"))
+        } throws CancellationException("cancelled")
+
+        val cancellation = try {
+            repository.detectAbusiveContent("content")
+            null
+        } catch (error: CancellationException) {
+            error
+        }
+
+        assertThat(cancellation).isNotNull()
+    }
+}


### PR DESCRIPTION
- 편지 전송 검사 팝업에 취소하기 버튼 추가
- 취소 시 검사 중단 및 편지 작성 화면 복귀

Closes #131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 유해 콘텐츠 검사 중 ‘취소하기’ 버튼을 제공하고, 취소 시 검사를 즉시 중단하도록 개선했습니다.
  * 검사 취소 후 전송 상태와 화면이 정상적으로 초기화됩니다.

* **버그 수정**
  * 검사 취소 시 로딩 다이얼로그가 안정적으로 닫히도록 개선했습니다.
  * 작업 취소 예외가 올바르게 처리되어 앱의 비동기 동작 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->